### PR TITLE
Switch to x11vnc as a DC backend dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,10 +42,10 @@ addons:
     - imagemagick
     # vncdotool
     - xfonts-base
-    - tightvncserver
+    - x11vnc
 # install any dependencies and build package
 install:
-- if [[ $INSTALL_VARIANT == "pip" ]]; then travis_retry pip install -r packaging/pip_requirements.txt; fi
+- if [[ $INSTALL_VARIANT == "pip" ]]; then travis_retry pip --default-timeout=60 install -r packaging/pip_requirements.txt; fi
 before_script:
 - export DISPLAY=:99.0
 - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile

--- a/TODO
+++ b/TODO
@@ -5,7 +5,6 @@ TODO - hierarchical notes
     - improve unit test coverage above 80%
         - change test_region_control to test all dc backends
             - switch from autopy to xdotool should be immediate
-            - for vncdotool use x11vnc and vncviewer :99 to connect to Xvfb
         - change test_region_expect to test more cv backends
         - tests as cartesian products of backends and methods
     - known problems

--- a/packaging/packager_deb.sh
+++ b/packaging/packager_deb.sh
@@ -2,7 +2,7 @@
 set -e
 
 readonly distro="${DISTRO:-ubuntu}"
-readonly version="${VERSION:-xenial}"
+readonly distro_version="${VERSION:-xenial}"
 
 # deb dependencies
 export DEBIAN_FRONTEND=noninteractive
@@ -13,20 +13,20 @@ apt-get -y install python3 python3-coverage
 apt-get -y install python3-pil
 # contour, template, feature, cascade, text matching
 apt-get -y install python3-numpy
-if [[ $version == "xenial" ]]; then
+if [[ $distro_version == "xenial" ]]; then
     export DISABLE_OPENCV=1
 else
     apt-get -y install python3-opencv
 fi
 # text matching
-if [[ $version == "focal" ]]; then
+if [[ $distro_version == "focal" ]]; then
     # TODO: OpenCV's OCR API for Tesseract 4.1+ is broken
     export DISABLE_OCR=1
 fi
 apt-get -y install tesseract-ocr
 # desktop control
 apt-get -y install xdotool x11-apps imagemagick
-apt-get -y install tightvncserver
+apt-get -y install x11vnc
 
 # pip dependencies (not available as DEB)
 apt-get -y install gcc libx11-dev libxtst-dev python3-dev libpng-dev python3-pip

--- a/packaging/packager_rpm.sh
+++ b/packaging/packager_rpm.sh
@@ -2,7 +2,7 @@
 set -e
 
 readonly distro="${DISTRO:-fedora}"
-readonly version="${VERSION:-30}"
+readonly distro_version="${VERSION:-30}"
 
 # rpm dependencies
 # python3
@@ -17,7 +17,7 @@ export DISABLE_OCR=1
 dnf -y install tesseract
 # desktop control
 dnf -y install xdotool xwd ImageMagick
-dnf -y install tigervnc-server
+dnf -y install x11vnc
 
 # pip dependencies (not available as RPM)
 dnf -y install gcc libX11-devel libXtst-devel python3-devel libpng-devel python3-pip redhat-rpm-config
@@ -47,7 +47,7 @@ sleep 3  # give xvfb some time to start
 # unit tests
 dnf install -y python3-PyQt5
 cd /lib/python3*/site-packages/guibot/tests
-if (( $version <= 30 )); then
+if (( distro_version <= 30 )); then
     COVERAGE="python3-coverage"
 else
     COVERAGE="coverage"


### PR DESCRIPTION
On Fedora 32, configuring TightVNC is a bit more difficult
and was leading to errors, so take this opportunity to move
to `x11vnc` and also check one of the TODO items.

Additionally, extend `pip` timeout as the default 15 seconds
sometimes is not enough.