### PR TITLE
Add support for nested steps files

### DIFF
--- a/docs/tutorials/Fallback Chains Tutorial.md
+++ b/docs/tutorials/Fallback Chains Tutorial.md
@@ -84,6 +84,20 @@ would be
     circle.png template-for-circle.match
     circle.png feature-for-circle.match
 
+It is also possible to have a fallback chain defined in multiple
+**steps** files, e.g.:
+
+    # file chain1.steps
+    circle.png template-for-circle.match
+    chain2.steps
+
+    # file chain2.steps
+    circle.png template-for-circle.match
+
+In this case, the resulting chain would be the same as above: the
+contents of the second file is appended to the contents of the first.
+This is useful when you want to group or categorize chains.
+
 Notice that we use the same data file but nothing stops us from using
 different ones for each model. We can change configurations, data, or
 both and add as many lines as we like but it is advisable that we

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -169,9 +169,7 @@ class ChainTest(unittest.TestCase):
     ]
 
     def setUp(self):
-        """
-        Create mocks and enable patches.
-        """
+        """Create mocks and enable patches."""
         # start with a clean environment
         self._old_paths = list(FileResolver._target_paths)
         FileResolver().clear()
@@ -195,9 +193,7 @@ class ChainTest(unittest.TestCase):
         return super().setUp()
 
     def tearDown(self):
-        """
-        Cleanup removing any patches and files created.
-        """
+        """Cleanup removing any patches and files created."""
         # start with a clean environment
         for p in self._old_paths:
             FileResolver().add_path(p)
@@ -260,10 +256,7 @@ class ChainTest(unittest.TestCase):
         return filename
 
     def test_stepsfile_lookup(self):
-        """
-        Test that the stepsfile will be searched using :py:class:`guibot.fileresolver.FileResolver`
-        if it is not initially found.
-        """
+        """Test that the stepsfile will be searched using :py:class:`guibot.fileresolver.FileResolver`."""
         tmp_dir = mkdtemp()
         tmp_steps_file = "{}/{}.steps".format(tmp_dir, self.stepsfile_missing)
         with open(tmp_steps_file, "w") as fp:
@@ -280,9 +273,7 @@ class ChainTest(unittest.TestCase):
             os.rmdir(tmp_dir)
 
     def test_finder_creation(self):
-        """
-        Test that all finders are correctly created from a stepsfile.
-        """
+        """Test that all finders are correctly created from a stepsfile."""
         stepsfile_contents = [
             "item_for_contour.png	some_contour_matchfile.match",
             "item_for_tempfeat.png	some_tempfeat_matchfile.match",
@@ -306,9 +297,7 @@ class ChainTest(unittest.TestCase):
         self.mock_match_read.assert_has_calls(calls)
 
     def test_steps_list(self):
-        """
-        Test that the resulting step chain contains all the items from the stepsfile.
-        """
+        """Test that the resulting step chain contains all the items from the stepsfile."""
         stepsfile_contents = [
             "item_for_contour.png	some_contour_matchfile.match",
             "item_for_tempfeat.png	some_tempfeat_matchfile.match",
@@ -324,9 +313,7 @@ class ChainTest(unittest.TestCase):
         self.assertEqual([type(s) for s in chain], expected_types)
 
     def test_step_save(self):
-        """
-        Test that dumping a chain to a file works and that the content is preserved.
-        """
+        """Test that dumping a chain to a file works and that the content is preserved."""
         # The Text target accepts either a file or a text string and we test
         # with both modes. For the first mode we need a real file.
         text_file = self._create_temp_file(prefix="some_text_file", extension=".txt")
@@ -397,9 +384,7 @@ class ChainTest(unittest.TestCase):
             FileResolver().remove_path(os.path.dirname(text_file))
 
     def test_malformed_stepsfile(self):
-        """
-        Test that the malformed stepsfiles are correctly handled.
-        """
+        """Test that the malformed stepsfiles are correctly handled."""
         stepsfile_contents = [
             "item_for_contour.png	some_contour_matchfile.match",
             "some_text_content	with	tabs	some_text_content.match"
@@ -414,9 +399,7 @@ class ChainTest(unittest.TestCase):
         self.assertRaises(IOError, self._build_chain, os.linesep.join(stepsfile_contents))
 
     def test_invalid_backends(self):
-        """
-        Test that unsupported backends are detected when loading and saving.
-        """
+        """Test that unsupported backends are detected when loading and saving."""
         # test on load
         stepsfile_contents = [
             "item_for_contour.png	some_contour_matchfile.match",


### PR DESCRIPTION
They are all chained together with the content of steps files
being added to the end.

When a reference to another steps file is encountered while
building the chain, the content of that file will be inserted in
the current position.