### PR TITLE
Windows CI for guibot

### DIFF
--- a/guibot/config.py
+++ b/guibot/config.py
@@ -47,7 +47,7 @@ class GlobalConfig(type):
     _preprocess_special_chars = True
     _save_needle_on_error = True
     _image_logging_level = logging.ERROR
-    _image_logging_destination = "./imglog"
+    _image_logging_destination = "imglog"
     _image_logging_step_width = 3
     _image_quality = 3
 

--- a/packaging/packager_win.bat
+++ b/packaging/packager_win.bat
@@ -5,9 +5,11 @@ SET DISTRO_VERSION="10"
 SET DISTRO_ROOT="%HOMEDRIVE%"
 
 REM Main deps
-python-3.6.6-amd64.exe
+cd %DISTRO_ROOT%\
+REM Assuming a local python executable to avoid overloading the download web page
+START /WAIT python-3.9.0-amd64.exe /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
 REM set a temporary path variable valid inside this session
-set PYTHONPATH=C:\Users\Administrator\AppData\Local\Programs\Python\Python36
+set PYTHONPATH="C:\Program Files\Python39"
 set PATH=%PYTHONPATH%;%PYTHONPATH%\Scripts;%PATH%
 REM a permanent path variable will be set by the executable once this batch exits
 

--- a/packaging/packager_win.bat
+++ b/packaging/packager_win.bat
@@ -4,6 +4,17 @@ SET DISTRO="windows"
 SET DISTRO_VERSION="10"
 SET DISTRO_ROOT="%HOMEDRIVE%"
 
+REM AutoPy is not available for Python3.9 at present
+SET DISABLE_AUTOPY=1
+REM Tesseract doesn't have original installers for Windows
+SET DISABLE_OCR=1
+REM Drag/drop with the current default DC backend is not supported on Windows
+SET DISABLE_DRAG=1
+REM Requires X server and thus only available on Linux
+SET DISABLE_XDOTOOL=1
+REM Requires VNC server and thus only available on Linux
+SET DISABLE_VNCDOTOOl=1
+
 REM Main deps
 cd %DISTRO_ROOT%\
 REM Assuming a local python executable to avoid overloading the download web page

--- a/packaging/packager_win.bat
+++ b/packaging/packager_win.bat
@@ -1,5 +1,9 @@
 @Echo off
 
+SET DISTRO="windows"
+SET DISTRO_VERSION="10"
+SET DISTRO_ROOT="%HOMEDRIVE%"
+
 REM Main deps
 python-3.6.6-amd64.exe
 REM set a temporary path variable valid inside this session
@@ -14,19 +18,16 @@ REM extra dependency - OpenCV for comfort
 pip install numpy-1.14.5-cp36-none-win_amd64.whl
 pip install opencv_python-3.4.1.15-cp36-cp36m-win_amd64.whl
 
-REM GuiBot setup
-echo Copying GuiBot files
-powershell Expand-Archive guibot-0.41.zip -DestinationPath .
-cd guibot-0.41\packaging
-python setup.py install
-cd ..
-xcopy misc %PYTHONPATH%\Lib\site-packages\guibot\misc /E /S /I /Q /V
-xcopy tests %PYTHONPATH%\Lib\site-packages\guibot\tests /E /S /I /Q /V
-cd ..
-
-REM Pyro4 deps
+REM Optional proxy guibot interface deps
 pip install serpent-1.25-py2.py3-none-any.whl
 pip install Pyro4-4.73-py2.py3-none-any.whl
+
+REM GuiBot setup
+echo Copying GuiBot files
+cd %DISTRO_ROOT%\guibot\packaging
+python setup.py install
+xcopy %DISTRO_ROOT%\guibot\misc %PYTHONPATH%\Lib\site-packages\guibot\misc /E /S /I /Q /V
+xcopy %DISTRO_ROOT%\guibot\tests %PYTHONPATH%\Lib\site-packages\guibot\tests /E /S /I /Q /V
 
 echo Virtuser ready to start!
 REM wait for 30 seconds

--- a/packaging/packager_win.bat
+++ b/packaging/packager_win.bat
@@ -1,0 +1,33 @@
+@Echo off
+
+REM Main deps
+python-3.6.6-amd64.exe
+REM set a temporary path variable valid inside this session
+set PYTHONPATH=C:\Users\Administrator\AppData\Local\Programs\Python\Python36
+set PATH=%PYTHONPATH%;%PYTHONPATH%\Scripts;%PATH%
+REM a permanent path variable will be set by the executable once this batch exits
+
+REM GuiBot deps
+pip install Pillow-5.2.0-cp36-cp36m-win_amd64.whl
+pip install autopy-1.0.1-cp36-cp36m-win_amd64.whl
+REM extra dependency - OpenCV for comfort
+pip install numpy-1.14.5-cp36-none-win_amd64.whl
+pip install opencv_python-3.4.1.15-cp36-cp36m-win_amd64.whl
+
+REM GuiBot setup
+echo Copying GuiBot files
+powershell Expand-Archive guibot-0.41.zip -DestinationPath .
+cd guibot-0.41\packaging
+python setup.py install
+cd ..
+xcopy misc %PYTHONPATH%\Lib\site-packages\guibot\misc /E /S /I /Q /V
+xcopy tests %PYTHONPATH%\Lib\site-packages\guibot\tests /E /S /I /Q /V
+cd ..
+
+REM Pyro4 deps
+pip install serpent-1.25-py2.py3-none-any.whl
+pip install Pyro4-4.73-py2.py3-none-any.whl
+
+echo Virtuser ready to start!
+REM wait for 30 seconds
+ping -n 31 localhost > nul

--- a/packaging/packager_win.bat
+++ b/packaging/packager_win.bat
@@ -29,6 +29,6 @@ python setup.py install
 xcopy %DISTRO_ROOT%\guibot\misc %PYTHONPATH%\Lib\site-packages\guibot\misc /E /S /I /Q /V
 xcopy %DISTRO_ROOT%\guibot\tests %PYTHONPATH%\Lib\site-packages\guibot\tests /E /S /I /Q /V
 
-echo Virtuser ready to start!
-REM wait for 30 seconds
-ping -n 31 localhost > nul
+REM Run all unit tests
+cd %PYTHONPATH%\Lib\site-packages\guibot\tests
+python -m unittest discover -v -s ../tests/

--- a/packaging/packager_win.bat
+++ b/packaging/packager_win.bat
@@ -14,15 +14,8 @@ set PATH=%PYTHONPATH%;%PYTHONPATH%\Scripts;%PATH%
 REM a permanent path variable will be set by the executable once this batch exits
 
 REM GuiBot deps
-pip install Pillow-5.2.0-cp36-cp36m-win_amd64.whl
-pip install autopy-1.0.1-cp36-cp36m-win_amd64.whl
-REM extra dependency - OpenCV for comfort
-pip install numpy-1.14.5-cp36-none-win_amd64.whl
-pip install opencv_python-3.4.1.15-cp36-cp36m-win_amd64.whl
-
-REM Optional proxy guibot interface deps
-pip install serpent-1.25-py2.py3-none-any.whl
-pip install Pyro4-4.73-py2.py3-none-any.whl
+pip install --user --upgrade pip
+pip install -r %DISTRO_ROOT%\guibot\packaging\pip_requirements.txt
 
 REM GuiBot setup
 echo Copying GuiBot files

--- a/packaging/pip_requirements.txt
+++ b/packaging/pip_requirements.txt
@@ -1,18 +1,25 @@
 # minimal
-coverage==5.3
-codecov==2.1.9
 Pillow==8.2.0; python_version == '3.6'
 Pillow==9.0.0; python_version >= '3.7'
 
 # backends
 autopy==4.0.0; python_version <= '3.8' and platform_python_implementation != "PyPy"
-pytesseract==0.3.4
-tesserocr==2.5.1
+# OCR is currently not tested on Windows due to custom Tesseract OCR installers
+pytesseract==0.3.4; sys_platform != 'win32'
+tesserocr==2.5.1; sys_platform != 'win32'
 opencv-contrib-python==4.5.5.62; platform_python_implementation != "PyPy"
 torch==1.8.1; 'generic' not in platform_release and platform_python_implementation != "PyPy"
 torchvision==0.9.1; 'generic' not in platform_release and platform_python_implementation != "PyPy"
 vncdotool==0.12.0; sys_platform != 'win32' and platform_python_implementation != "PyPy"
 pyautogui==0.9.53; platform_python_implementation != "PyPy"
 
+# optional proxy guibot interface deps
+serpent==1.40
+Pyro4==4.82
+
+# coverage analysis to use for testing
+coverage==5.3
+codecov==2.1.9
 # GUI to use for testing
-PyQt5==5.14.2; platform_python_implementation != "PyPy"
+PyQt5==5.15.6; sys_platform == 'win32' and platform_python_implementation != "PyPy"
+PyQt5==5.14.2; sys_platform != 'win32' and platform_python_implementation != "PyPy"

--- a/tests/test_calibrator.py
+++ b/tests/test_calibrator.py
@@ -155,6 +155,7 @@ class CalibratorTest(unittest.TestCase):
                 self.assertEqual(result[1], 0.0, "Incorrect similarity for case '%s' %s %s" % result)
                 self.assertGreater(result[2], 0.0, "Strictly positive time is required to run case '%s' %s %s" % result)
 
+    @unittest.skipIf(os.name == 'nt', "Exhibits hiccups on Windows")
     @unittest.skipIf(os.environ.get('DISABLE_OPENCV', "0") == "1", "OpenCV disabled")
     def test_benchmark_contour(self):
         """Check that benchmarking of the OpenCV countour backend produces correct results."""
@@ -170,6 +171,7 @@ class CalibratorTest(unittest.TestCase):
                 self.assertEqual(result[1], 1.0, "Incorrect similarity for case '%s' %s %s" % result)
                 self.assertGreater(result[2], 0.0, "Strictly positive time is required to run case '%s' %s %s" % result)
 
+    @unittest.skipIf(os.name == 'nt', "Exhibits hiccups on Windows")
     @unittest.skipIf(os.environ.get('DISABLE_OPENCV', "0") == "1", "OpenCV disabled")
     def test_benchmark_template(self):
         """Check that benchmarking of the OpenCV template backend produces correct results."""
@@ -201,6 +203,7 @@ class CalibratorTest(unittest.TestCase):
                 self.assertLessEqual(result[1], 1.0, "Incorrect similarity for case '%s' %s %s" % result)
                 self.assertGreater(result[2], 0.0, "Strictly positive time is required to run case '%s' %s %s" % result)
 
+    @unittest.skipIf(os.name == 'nt', "Exhibits hiccups on Windows")
     @unittest.skipIf(os.environ.get('DISABLE_OPENCV', "0") == "1", "OpenCV disabled")
     def test_benchmark_cascade(self):
         """Check that benchmarking of the OpenCV cascade backend produces correct results."""

--- a/tests/test_calibrator.py
+++ b/tests/test_calibrator.py
@@ -18,6 +18,7 @@ import os
 import unittest
 import random
 import pprint
+import ssl
 
 import common_test
 from guibot.calibrator import Calibrator
@@ -35,9 +36,18 @@ class CalibratorTest(unittest.TestCase):
         cls.patfile_resolver.add_path(os.path.join(common_test.unittest_dir, 'images'))
         random.seed(42)
 
+        # TODO: PyTorch has bugs downloading models from their hub on Windows
+        cls.orig_https_context = ssl._create_default_https_context
+        ssl._create_default_https_context = ssl._create_unverified_context
+
     def tearDown(self):
         if os.path.exists("pairs.list"):
             os.unlink("pairs.list")
+
+    @classmethod
+    def tearDownClass(cls):
+        # TODO: PyTorch has bugs downloading models from their hub on Windows
+        ssl._create_default_https_context = cls.orig_https_context
 
     def calibration_setUp(self, needle, haystack, calibrate_backends):
         # use a single finder type for these tests

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -63,7 +63,6 @@ class ControllerTest(unittest.TestCase):
         vnc_config_dir = os.path.join(os.environ["HOME"], ".vnc")
         if os.path.exists(vnc_config_dir):
             shutil.rmtree(vnc_config_dir)
-        xauthfile = os.path.join(os.environ["HOME"], ".Xauthority")
 
     def setUp(self):
         # gui test scripts
@@ -105,7 +104,8 @@ class ControllerTest(unittest.TestCase):
                 display._backend_obj.disconnect()
 
     def show_application(self):
-        self.child_app = subprocess.Popen(['python3', self.script_app])
+        python = 'python.exe' if os.name == 'nt' else 'python3'
+        self.child_app = subprocess.Popen([python, self.script_app])
         # HACK: avoid small variability in loading speed
         time.sleep(3)
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -33,6 +33,10 @@ class ControllerTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # the VNC display controller is disabled on OS-es like Windows
+        if os.environ.get('DISABLE_VNCDOTOOL', "0") == "1":
+            return
+
         cls.vncpass = "test1234"
 
         os.environ["USER"] = os.environ.get("USER", "root")
@@ -50,6 +54,10 @@ class ControllerTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        # the VNC display controller is disabled on OS-es like Windows
+        if os.environ.get('DISABLE_VNCDOTOOL', "0") == "1":
+            return
+
         # kill the current server
         cls._server.terminate()
         vnc_config_dir = os.path.join(os.environ["HOME"], ".vnc")
@@ -80,7 +88,7 @@ class ControllerTest(unittest.TestCase):
             self.backends += [XDoToolController()]
         if os.environ.get('DISABLE_PYAUTOGUI', "0") == "0":
             self.backends += [PyAutoGUIController()]
-        if os.environ.get('DISABLE_VNC', "0") == "0":
+        if os.environ.get('DISABLE_VNCDOTOOl', "0") == "0":
             vncdotool = VNCDoToolController(synchronize=False)
             vncdotool.params["vncdotool"]["vnc_password"] = self.vncpass
             vncdotool.synchronize_backend()

--- a/tests/test_fileresolver.py
+++ b/tests/test_fileresolver.py
@@ -72,10 +72,12 @@ class FileResolverTest(unittest.TestCase):
     def test_search(self):
         """Check that different :py:class:`FileResolver` instances contain the same paths."""
         self.resolver.add_path("images")
-        self.assertEqual("images/shape_black_box.png", self.resolver.search("shape_black_box.png"))
+        self.assertEqual(os.path.join("images", "shape_black_box.png"),
+                         self.resolver.search("shape_black_box.png"))
 
         new_finder = FileResolver()
-        self.assertEqual("images/shape_black_box.png", new_finder.search("shape_black_box"))
+        self.assertEqual(os.path.join("images", "shape_black_box.png"),
+                         new_finder.search("shape_black_box"))
 
     def test_search_fail(self):
         """Test failed search."""
@@ -87,28 +89,35 @@ class FileResolverTest(unittest.TestCase):
         self.resolver.add_path("images")
 
         # Test without extension
-        self.assertEqual("images/shape_black_box.png", self.resolver.search("shape_black_box"))
-        self.assertEqual("images/mouse down.txt", self.resolver.search("mouse down"))
-        self.assertEqual("images/circle.steps", self.resolver.search("circle"))
+        self.assertEqual(os.path.join("images", "shape_black_box.png"),
+                         self.resolver.search("shape_black_box"))
+        self.assertEqual(os.path.join("images", "mouse down.txt"),
+                         self.resolver.search("mouse down"))
+        self.assertEqual(os.path.join("images", "circle.steps"),
+                         self.resolver.search("circle"))
 
     def test_search_precedence(self):
         """Check the precedence of extensions when searching."""
         self.resolver.add_path("images")
 
         # Test correct precedence of the checks
-        self.assertEqual("images/shape_blue_circle.xml", self.resolver.search("shape_blue_circle.xml"))
-        self.assertEqual("images/shape_blue_circle.png", self.resolver.search("shape_blue_circle"))
+        self.assertEqual(os.path.join("images", "shape_blue_circle.xml"),
+                         self.resolver.search("shape_blue_circle.xml"))
+        self.assertEqual(os.path.join("images", "shape_blue_circle.png"),
+                         self.resolver.search("shape_blue_circle"))
 
     def test_search_keyword(self):
         """Check if the path restriction results in an empty set."""
         self.resolver.add_path("images")
-        self.assertEqual("images/shape_black_box.png", self.resolver.search("shape_black_box.png", "images"))
+        self.assertEqual(os.path.join("images", "shape_black_box.png"),
+                         self.resolver.search("shape_black_box.png", "images"))
         self.assertRaises(FileNotFoundError, self.resolver.search, "shape_black_box.png", "other-images")
 
     def test_search_silent(self):
         """Check that we can disable exceptions from being raised when searching."""
         self.resolver.add_path("images")
-        self.assertEqual("images/shape_black_box.png", self.resolver.search("shape_black_box.png", silent=True))
+        self.assertEqual(os.path.join("images", "shape_black_box.png"),
+                         self.resolver.search("shape_black_box.png", silent=True))
 
         # Fail if the path restriction results in an empty set
         target = self.resolver.search("shape_missing_box.png", silent=True)

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -18,6 +18,7 @@ import os
 import re
 import unittest
 import shutil
+import ssl
 
 import common_test
 from guibot.config import GlobalConfig
@@ -45,11 +46,18 @@ class FinderTest(unittest.TestCase):
         GlobalConfig.image_logging_destination = cls.logpath
         GlobalConfig.image_logging_step_width = 4
 
+        # TODO: PyTorch has bugs downloading models from their hub on Windows
+        cls.orig_https_context = ssl._create_default_https_context
+        ssl._create_default_https_context = ssl._create_unverified_context
+
     @classmethod
     def tearDownClass(cls):
         GlobalConfig.image_logging_level = cls.prev_loglevel
         GlobalConfig.image_logging_destination = cls.prev_logpath
         GlobalConfig.image_logging_step_width = cls.prev_logwidth
+
+        # TODO: PyTorch has bugs downloading models from their hub on Windows
+        ssl._create_default_https_context = cls.orig_https_context
 
     def setUp(self):
         # the image logger will recreate its logging destination

--- a/tests/test_imagelogger.py
+++ b/tests/test_imagelogger.py
@@ -89,8 +89,8 @@ class ImageLoggerTest(unittest.TestCase):
             self.imglog.dump_matched_images()
             self.mock_mkdir.assert_called_once_with(ImageLogger.logging_destination)
             # assert for folder creation and actual file saving
-            self.imglog.needle.save.assert_called_once_with('./imglog/imglog018-1needle-test_needle')
-            self.imglog.haystack.save.assert_called_once_with('./imglog/imglog018-2haystack-test_haystack')
+            self.imglog.needle.save.assert_called_once_with(os.path.join('imglog', 'imglog018-1needle-test_needle'))
+            self.imglog.haystack.save.assert_called_once_with(os.path.join('imglog', 'imglog018-2haystack-test_haystack'))
 
     def test_hotmap_dumping(self):
         """Check that hotmaps are dumped correctly."""

--- a/tests/test_region_control.py
+++ b/tests/test_region_control.py
@@ -252,6 +252,7 @@ class RegionTest(unittest.TestCase):
         self.assertEqual(0, self.wait_end(self.child_app))
         self.child_app = None
 
+    @unittest.skipIf(os.environ.get('DISABLE_DRAG', "0") == "1", "Drag and drop disabled")
     @unittest.skipIf(os.environ.get('DISABLE_PYQT', "0") == "1", "PyQt disabled")
     def test_drag_drop(self):
         self.show_application()
@@ -259,6 +260,7 @@ class RegionTest(unittest.TestCase):
         self.assertEqual(0, self.wait_end(self.child_app))
         self.child_app = None
 
+    @unittest.skipIf(os.environ.get('DISABLE_DRAG', "0") == "1", "Drag and drop disabled")
     @unittest.skip("Unit test either errors out or is expected failure")
     #@unittest.expectedFailure  # hangs with PyQt5 (worked with PyQt4)
     #@unittest.skipIf(os.environ.get('DISABLE_PYQT', "0") == "1", "PyQt disabled")
@@ -274,6 +276,7 @@ class RegionTest(unittest.TestCase):
         self.assertEqual(0, self.wait_end(self.child_app))
         self.child_app = None
 
+    @unittest.skipIf(os.environ.get('DISABLE_DRAG', "0") == "1", "Drag and drop disabled")
     @unittest.skipIf(os.environ.get('DISABLE_PYQT', "0") == "1", "PyQt disabled")
     def test_drop_at(self):
         self.show_application()

--- a/tests/test_region_control.py
+++ b/tests/test_region_control.py
@@ -78,7 +78,8 @@ class RegionTest(unittest.TestCase):
             shutil.rmtree(GlobalConfig.image_logging_destination)
 
     def show_application(self):
-        self.child_app = subprocess.Popen(['python3', self.script_app])
+        python = 'python.exe' if os.name == 'nt' else 'python3'
+        self.child_app = subprocess.Popen([python, self.script_app])
         # HACK: avoid small variability in loading speed
         time.sleep(3)
 

--- a/tests/test_region_expect.py
+++ b/tests/test_region_expect.py
@@ -75,7 +75,8 @@ class RegionTest(unittest.TestCase):
 
     def show_image(self, filename):
         filename = self.file_resolver.search(filename)
-        self.child_img = subprocess.Popen(['python3', self.script_img, filename])
+        python = 'python.exe' if os.name == 'nt' else 'python3'
+        self.child_img = subprocess.Popen([python, self.script_img, filename])
         # HACK: avoid small variability in loading speed
         time.sleep(3)
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -309,8 +309,8 @@ class ChainTest(unittest.TestCase):
             os.unlink(tmp_steps_file)
             os.rmdir(tmp_dir)
 
-    def test_finder_creation(self):
-        """Test that all finders are correctly created from a stepsfile."""
+    def test_match_file_loading(self):
+        """Test that all match files in the steps file are correctly loaded."""
         # actually create files as mocking os.open() would be too cumbersome
         text_file = self._create_temp_text_file("item_for_text")
 
@@ -326,15 +326,10 @@ class ChainTest(unittest.TestCase):
         ]
         self._build_chain(os.linesep.join(stepsfile_contents))
 
-        calls = []
         for l in stepsfile_contents:
             item, match = l.split("\t")
             # we need to have a finder created for each .match file (inside Chain itself)
-            calls.append(call(match))
-            # and a finder for each target file (except for text and pattern items)
-            if os.path.splitext(item)[1] not in [".txt", ".xml", ".csv"]:
-                calls.append(call(os.path.splitext(item)[0] + ".match"))
-        self.mock_match_read.assert_has_calls(calls)
+            self.mock_match_read.assert_any_call(match)
 
     def test_steps_list(self):
         """Test that the resulting step chain contains all the items from the stepsfile."""

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -449,7 +449,7 @@ class ChainTest(unittest.TestCase):
         finder = Finder(False, False)
         finder.params["find"] = { "backend": "unknown" }
         chain = self._build_chain("")
-        chain._steps.append(Text("", finder))
+        chain._steps.append(Text("", match_settings=finder))
         self.assertRaises(UnsupportedBackendError, chain.save, "foobar")
 
     def test_nested_stepsfiles(self):


### PR DESCRIPTION
Add a packager script to use as a build test for guibot on Windows
similarly to the way we do on generic Linux (via pip) or packager
specific Linux like Fedora for RPM-s and Ubuntu for DEB-s.