### PR TITLE
add quotes to solve problems with tesseract datapaths containing spaces

### DIFF
--- a/guibot/finder.py
+++ b/guibot/finder.py
@@ -2019,7 +2019,7 @@ class TextFinder(ContourFinder):
             if backend == "pytesseract":
                 import pytesseract
                 self.ocr = pytesseract
-                self.ocr_config = r"--tessdata-dir %s --oem %s --psm %s "
+                self.ocr_config = r"--tessdata-dir '%s' --oem %s --psm %s "
                 self.ocr_config %= (tessdata_path,
                                     self.params["ocr"]["oem"].value,
                                     self.params["ocr"]["psmode"].value)


### PR DESCRIPTION
Add quotes around the tesseract datapath in the tesseract command to use datapaths containing spaces without getting errors. This should close #46.