### PR TITLE
Allow empty CVParameter value by default

### DIFF
--- a/guibot/finder.py
+++ b/guibot/finder.py
@@ -138,7 +138,7 @@ class CVParameter(object):
         :raises: :py:class:`ValueError` if unsupported type is encountered
         """
         args = []
-        string_args = re.match(r"<value='(.+)' min='(-?[\d.None]+)' max='([\d.None]+)'"
+        string_args = re.match(r"<value='(.*)' min='(-?[\d.None]+)' max='([\d.None]+)'"
                                r" delta='([\d.]+)' tolerance='([\d.]+)' fixed='(\w+)' enumerated='(\w+)'>",
                                raw).group(1, 2, 3, 4, 5, 6)
 

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -1054,5 +1054,15 @@ class CVParameterTest(unittest.TestCase):
         parsed = CVParameter.from_string("<value='123456789.' min='None' max='None' delta='1030.25' tolerance='10.2' fixed='False' enumerated='False'>")
         self.assertEqual(parsed, expected)
 
+    def test_empty_value(self):
+        """Check that the parser handles empty CVParameter value gracefully."""
+        expected = CVParameter(
+            "", min_val=None, max_val=None, delta=10.0,
+            tolerance=1.0, fixed=True, enumerated=False
+        )
+        parsed = CVParameter.from_string("<value='' min='None' max='None' delta='10.0' tolerance='1.0' fixed='True' enumerated='False'>")
+        self.assertEqual(parsed, expected)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This pull requests closes #44. It changes the regex pattern used for parsing arguments in the match file to accept empty values for the value field also.