### PR TITLE
Add support for python versions 3.10, 3.11, and 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10.8, 3.11, 3.12]
         install_variant: ["pip"]
         include:
         - python-version: 3.10.8
@@ -75,6 +75,9 @@ jobs:
       - name: Run current semi-isolation semi-integration tests (to be separated in the future)
         run: |
           if [[ ${{ matrix.python-version }} == '3.9' ]]; then export DISABLE_AUTOPY=1; fi
+          if [[ ${{ matrix.python-version }} == '3.10.8' ]]; then export DISABLE_AUTOPY=1; fi
+          if [[ ${{ matrix.python-version }} == '3.11' ]]; then export DISABLE_AUTOPY=1; fi
+          if [[ ${{ matrix.python-version }} == '3.12' ]]; then export DISABLE_AUTOPY=1; fi
           if [[ ${{ matrix.install_variant }} != "pip" ]]; then cd packaging && bash packager_docker.sh;
           else cd tests && bash coverage_analysis.sh; fi
         env:

--- a/packaging/packager_deb.sh
+++ b/packaging/packager_deb.sh
@@ -37,6 +37,8 @@ pip3 install autopy==4.0.0
 pip3 install vncdotool==0.12.0
 apt-get -y install xdotool x11-apps imagemagick
 apt-get -y install python3-tk scrot
+# TODO: install PyScreeze separately to replace the one PyAutoGUI will install which is incompatible with the current Pillow version 
+pip3 install pyscreeze==0.1.28
 pip3 install pyautogui==0.9.53
 apt-get -y install x11vnc
 

--- a/packaging/packager_pip.sh
+++ b/packaging/packager_pip.sh
@@ -12,6 +12,9 @@ readonly release_tag="${RELEASE_TAG:-}"
 
 # disable tests and support of backends based on python versions
 if [[ $python_version == '3.9' ]]; then export DISABLE_AUTOPY=1; fi
+if [[ $python_version == '3.10.8' ]]; then export DISABLE_AUTOPY=1; fi
+if [[ $python_version == '3.11' ]]; then export DISABLE_AUTOPY=1; fi
+if [[ $python_version == '3.12' ]]; then export DISABLE_AUTOPY=1; fi
 
 # environment dependencies not provided by pip
 # python3

--- a/packaging/packager_rpm.sh
+++ b/packaging/packager_rpm.sh
@@ -31,6 +31,8 @@ pip3 install vncdotool==0.12.0
 dnf -y install xdotool xwd ImageMagick
 # NOTE: PyAutoGUI's scrot dependencies are broken on Fedora 33- so we don't support these
 dnf -y install python3-tkinter scrot
+# TODO: install PyScreeze separately to replace the one PyAutoGUI will install which is incompatible with the current Pillow version
+pip3 install pyscreeze==0.1.28
 pip3 install pyautogui==0.9.53
 dnf -y install x11vnc
 

--- a/packaging/pip_requirements.txt
+++ b/packaging/pip_requirements.txt
@@ -1,6 +1,6 @@
 # minimal
-Pillow==8.2.0; python_version == '3.6'
-Pillow==9.0.0; python_version >= '3.7'
+Pillow==9.3.0; python_version >= '3.7' and python_version < '3.12'
+Pillow==10.3.0; python_version >= '3.12'
 
 # backends
 autopy==4.0.0; python_version <= '3.8' and platform_python_implementation != "PyPy"
@@ -8,10 +8,14 @@ autopy==4.0.0; python_version <= '3.8' and platform_python_implementation != "Py
 pytesseract==0.3.4; sys_platform != 'win32'
 tesserocr==2.5.1; sys_platform != 'win32'
 opencv-contrib-python==4.5.5.62; platform_python_implementation != "PyPy"
-torch==1.8.1; 'generic' not in platform_release and platform_python_implementation != "PyPy"
-torchvision==0.9.1; 'generic' not in platform_release and platform_python_implementation != "PyPy"
+torch==1.13.0; python_version == '3.7'
+torchvision==0.14.0; python_version == '3.7'
+torch==2.2.0; python_version != '3.7' and 'generic' not in platform_release and platform_python_implementation != "PyPy"
+torchvision==0.17.0 ; python_version != '3.7' and 'generic' not in platform_release and platform_python_implementation != "PyPy"
 vncdotool==0.12.0; sys_platform != 'win32' and platform_python_implementation != "PyPy"
 pyautogui==0.9.53; platform_python_implementation != "PyPy"
+# NOTE: These decared version of Pillow has issues with the latest Pyscreeze 0.1.30 thus there is a restrain on Pyscreeze installation
+pyscreeze==0.1.28
 
 # optional proxy guibot interface deps
 serpent==1.40


### PR DESCRIPTION
Update python versions and related backends with a few workarounds for outdated docker variants.