### PR TITLE
Move static attributes from GlobalConfig to controller params

### DIFF
--- a/docs/examples/custom_controller.py
+++ b/docs/examples/custom_controller.py
@@ -248,8 +248,6 @@ class QemuController(Controller):
 
         See base method for details.
         """
-        toggle_timeout = GlobalConfig.toggle_delay
-        click_timeout = GlobalConfig.click_delay
         button = self._mousemap.LEFT_BUTTON if button is None else button
         if modifiers != None:
             self.keys_toggle(modifiers, True)
@@ -257,9 +255,9 @@ class QemuController(Controller):
             self._backend_obj.mouse_button(button)
             # BUG: QEMU's monitor doesn't handle click events sent too fast,
             # so we sleep a bit between mouse up and mouse down
-            time.sleep(toggle_timeout)
+            time.sleep(self.params["control"]["mouse_toggle_delay"])
             self._backend_obj.mouse_button(button)
-            time.sleep(click_timeout)
+            time.sleep(self.params["control"]["after_click_delay"])
         if modifiers != None:
             self.keys_toggle(modifiers, False)
 
@@ -314,6 +312,7 @@ class QemuController(Controller):
 
         See base method for details.
         """
+        time.sleep(self.params["control"]["delay_before_keys"])
         if modifiers != None:
             self.keys_toggle(modifiers, True)
 
@@ -350,7 +349,7 @@ class QemuController(Controller):
                 elif special_chars.has_key(char) and GlobalConfig.preprocess_special_chars:
                     char = "shift-%s" % special_chars[char]
                 self._backend_obj.sendkey(char, hold_time=1)
-                time.sleep(GlobalConfig.delay_between_keys)
+                time.sleep(self.params["control"]["delay_between_keys"])
 
         if modifiers != None:
             self.keys_toggle(modifiers, False)

--- a/guibot/config.py
+++ b/guibot/config.py
@@ -50,12 +50,8 @@ class GlobalConfig(type):
     """
 
     # operational parameters shared between all instances
-    _toggle_delay = 0.05
-    _click_delay = 0.1
     _drag_delay = 0.5
     _drop_delay = 0.5
-    _keys_delay = 0.2
-    _type_delay = 0.1
     _rescan_speed_on_find = 0.2
     _wait_for_animations = False
     _smooth_mouse_drag = True
@@ -79,38 +75,6 @@ class GlobalConfig(type):
     _text_ocr_backend = "pytesseract"
     _deep_learn_backend = "pytorch"
     _hybrid_match_backend = "template"
-
-    def toggle_delay(cls, value: float = None) -> float | None:
-        """
-        Get or set property attribute.
-
-        :param value: time interval between mouse down and up in a click
-        :returns: current value if no argument was passed otherwise None
-        """
-        if value is None:
-            return cls._toggle_delay
-        else:
-            cls._toggle_delay = value
-            return None
-
-    #: time interval between mouse down and up in a click
-    toggle_delay = property(fget=toggle_delay, fset=toggle_delay)
-
-    def click_delay(cls, value: float = None) -> float | None:
-        """
-        Get or set property attribute.
-
-        :param value: time interval after a click (in a double or n-click)
-        :returns: current value if no argument was passed otherwise None
-        """
-        if value is None:
-            return cls._click_delay
-        else:
-            cls._click_delay = value
-            return None
-
-    #: time interval after a click (in a double or n-click)
-    click_delay = property(fget=click_delay, fset=click_delay)
 
     def delay_after_drag(cls, value: float = None) -> float | None:
         """
@@ -143,38 +107,6 @@ class GlobalConfig(type):
 
     #: timeout before drop operation
     delay_before_drop = property(fget=delay_before_drop, fset=delay_before_drop)
-
-    def delay_before_keys(cls, value: float = None) -> float | None:
-        """
-        Get or set property attribute.
-
-        :param value: timeout before key press operation
-        :returns: current value if no argument was passed otherwise None
-        """
-        if value is None:
-            return cls._keys_delay
-        else:
-            cls._keys_delay = value
-            return None
-
-    #: timeout before key press operation
-    delay_before_keys = property(fget=delay_before_keys, fset=delay_before_keys)
-
-    def delay_between_keys(cls, value: float = None) -> float | None:
-        """
-        Get or set property attribute.
-
-        :param value: time interval between two consecutively typed keys
-        :returns: current value if no argument was passed otherwise None
-        """
-        if value is None:
-            return cls._type_delay
-        else:
-            cls._type_delay = value
-            return None
-
-    #: time interval between two consecutively typed keys
-    delay_between_keys = property(fget=delay_between_keys, fset=delay_between_keys)
 
     def rescan_speed_on_find(cls, value: float = None) -> float | None:
         """

--- a/guibot/controller.py
+++ b/guibot/controller.py
@@ -167,6 +167,10 @@ class Controller(LocalConfig):
         log.log(9, "Setting backend for %s to %s", category, backend)
         self.params[category] = {}
         self.params[category]["backend"] = backend
+        self.params[category]["mouse_toggle_delay"] = 0.05
+        self.params[category]["after_click_delay"] = 0.1
+        self.params[category]["delay_between_keys"] = 0.1
+        self.params[category]["delay_before_keys"] = 0.2
         log.log(9, "%s %s\n", category, self.params[category])
 
     def configure_backend(
@@ -344,6 +348,7 @@ class Controller(LocalConfig):
         :param keys: characters or special keys depending on the backend
                      (see :py:class:`inputmap.Key` for extensive list)
         """
+        time.sleep(self.params["control"]["delay_before_keys"])
         # BUG: pressing multiple times the same key does not work?
         self.keys_toggle(keys, True)
         self.keys_toggle(keys, False)
@@ -523,17 +528,15 @@ class AutoPyController(Controller):
 
         See base method for details.
         """
-        toggle_timeout = GlobalConfig.toggle_delay
-        click_timeout = GlobalConfig.click_delay
         button = self._mousemap.LEFT_BUTTON if button is None else button
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
         for _ in range(count):
             self._backend_obj.mouse.click(button)
             # BUG: the mouse button of autopy is pressed down forever (on LEFT)
-            time.sleep(toggle_timeout)
+            time.sleep(self.params["control"]["mouse_toggle_delay"])
             self.mouse_up(button)
-            time.sleep(click_timeout)
+            time.sleep(self.params["control"]["after_click_delay"])
         if modifiers is not None:
             self.keys_toggle(modifiers, False)
 
@@ -576,13 +579,14 @@ class AutoPyController(Controller):
 
         See base method for details.
         """
+        time.sleep(self.params["control"]["delay_before_keys"])
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
 
         for part in text:
             for char in str(part):
                 self._backend_obj.key.tap(char, [])
-                time.sleep(GlobalConfig.delay_between_keys)
+                time.sleep(self.params["control"]["delay_between_keys"])
             # alternative option:
             # autopy.key.type_string(text)
 
@@ -748,8 +752,6 @@ class XDoToolController(Controller):
 
         See base method for details.
         """
-        toggle_timeout = GlobalConfig.toggle_delay
-        click_timeout = GlobalConfig.click_delay
         button = self._mousemap.LEFT_BUTTON if button is None else button
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
@@ -757,9 +759,9 @@ class XDoToolController(Controller):
             # BUG: the xdotool click is too fast and non-configurable with timeout
             # self._backend_obj.run("click", str(button))
             self.mouse_down(button)
-            time.sleep(toggle_timeout)
+            time.sleep(self.params["control"]["mouse_toggle_delay"])
             self.mouse_up(button)
-            time.sleep(click_timeout)
+            time.sleep(self.params["control"]["after_click_delay"])
         if modifiers is not None:
             self.keys_toggle(modifiers, False)
 
@@ -805,6 +807,7 @@ class XDoToolController(Controller):
 
         See base method for details.
         """
+        time.sleep(self.params["control"]["delay_before_keys"])
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
 
@@ -968,8 +971,6 @@ class VNCDoToolController(Controller):
 
         See base method for details.
         """
-        toggle_timeout = GlobalConfig.toggle_delay
-        click_timeout = GlobalConfig.click_delay
         button = self._mousemap.LEFT_BUTTON if button is None else button
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
@@ -978,9 +979,9 @@ class VNCDoToolController(Controller):
             # sent too fast, so we sleep between mouse up and down and avoid mousePress
             # self._backend_obj.mousePress(button)
             self.mouse_down(button)
-            time.sleep(toggle_timeout)
+            time.sleep(self.params["control"]["mouse_toggle_delay"])
             self.mouse_up(button)
-            time.sleep(click_timeout)
+            time.sleep(self.params["control"]["after_click_delay"])
         if modifiers is not None:
             self.keys_toggle(modifiers, False)
 
@@ -1032,6 +1033,7 @@ class VNCDoToolController(Controller):
 
         See base method for details.
         """
+        time.sleep(self.params["control"]["delay_before_keys"])
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
 
@@ -1045,7 +1047,7 @@ class VNCDoToolController(Controller):
                     char = "space"
                 elif char == "\n":
                     char = "return"
-                time.sleep(GlobalConfig.delay_between_keys)
+                time.sleep(self.params["control"]["delay_between_keys"])
                 self._backend_obj.keyPress(char)
 
         if modifiers is not None:
@@ -1182,8 +1184,6 @@ class PyAutoGUIController(Controller):
 
         See base method for details.
         """
-        toggle_timeout = GlobalConfig.toggle_delay
-        click_timeout = GlobalConfig.click_delay
         button = self._mousemap.LEFT_BUTTON if button is None else button
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
@@ -1192,9 +1192,9 @@ class PyAutoGUIController(Controller):
             # control the toggle speed
             # self._backend_obj.click(clicks=count, interval=click_timeout, button=button)
             self._backend_obj.mouseDown(button=button)
-            time.sleep(toggle_timeout)
+            time.sleep(self.params["control"]["mouse_toggle_delay"])
             self._backend_obj.mouseUp(button=button)
-            time.sleep(click_timeout)
+            time.sleep(self.params["control"]["after_click_delay"])
         if modifiers is not None:
             self.keys_toggle(modifiers, False)
 
@@ -1253,11 +1253,14 @@ class PyAutoGUIController(Controller):
 
         See base method for details.
         """
+        time.sleep(self.params["control"]["delay_before_keys"])
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
 
         for part in text:
-            self._backend_obj.typewrite(part, interval=GlobalConfig.delay_between_keys)
+            self._backend_obj.typewrite(
+                part, interval=self.params["control"]["delay_between_keys"]
+            )
 
         if modifiers is not None:
             self.keys_toggle(modifiers, False)

--- a/guibot/region.py
+++ b/guibot/region.py
@@ -1033,7 +1033,6 @@ class Region(object):
             self.press_keys(['a', 'b', 3])
         """
         keys_list = self._parse_keys(keys)
-        time.sleep(GlobalConfig.delay_before_keys)
         self.dc_backend.keys_press(keys_list)
         return self
 
@@ -1050,7 +1049,6 @@ class Region(object):
         """
         keys_list = self._parse_keys(keys, target_or_location)
         match = self.click(target_or_location)
-        time.sleep(GlobalConfig.delay_before_keys)
         self.dc_backend.keys_press(keys_list)
         return match
 
@@ -1172,7 +1170,6 @@ class Region(object):
         typing special keys.
         """
         text_list = self._parse_text(text)
-        time.sleep(GlobalConfig.delay_before_keys)
         if modifiers is not None:
             if isinstance(modifiers, str):
                 modifiers = [modifiers]
@@ -1198,7 +1195,6 @@ class Region(object):
         match = None
         if target_or_location is not None:
             match = self.click(target_or_location)
-        time.sleep(GlobalConfig.delay_before_keys)
         if modifiers is not None:
             if isinstance(modifiers, str):
                 modifiers = [modifiers]


### PR DESCRIPTION
Update key-value pairs in the params dictionary for a generic controller. We can now set click timeout and other settings for each separate controller instance.