### PR TITLE
Enable image logging also for display controllers

### DIFF
--- a/guibot/config.py
+++ b/guibot/config.py
@@ -642,6 +642,12 @@ class LocalConfig(object):
         self.categories["type"] = "backend_types"
         self.algorithms["backend_types"] = ("cv", "dc")
 
+        # other attributes
+        from .imagelogger import ImageLogger
+
+        self.imglog = ImageLogger()
+        self.imglog.log = self.log
+
         if configure:
             self.__configure_backend()
         if synchronize:

--- a/guibot/controller.py
+++ b/guibot/controller.py
@@ -29,12 +29,13 @@ import os
 import re
 import time
 import logging
-
+import numpy
 import PIL.Image
 from tempfile import NamedTemporaryFile
 
 from . import inputmap
 from .config import GlobalConfig, LocalConfig
+from .imagelogger import ImageLogger
 from .target import Image
 from .location import Location
 from .errors import *
@@ -348,6 +349,8 @@ class Controller(LocalConfig):
         :param keys: characters or special keys depending on the backend
                      (see :py:class:`inputmap.Key` for extensive list)
         """
+        self.imglog.type = "keys"
+        self.imglog.log(30)
         time.sleep(self.params["control"]["delay_before_keys"])
         # BUG: pressing multiple times the same key does not work?
         self.keys_toggle(keys, True)
@@ -365,6 +368,35 @@ class Controller(LocalConfig):
         raise NotImplementedError(
             "Method is not available for this controller implementation"
         )
+
+    def log(self, lvl: int) -> None:
+        """
+        Log images with an arbitrary logging level.
+
+        :param lvl: logging level for the message
+        """
+        # below selected logging level
+        if lvl < self.imglog.logging_level:
+            self.imglog.clear()
+            return
+
+        self.imglog.hotmaps += [numpy.array(self.capture_screen().pil_image)]
+        self.imglog.draw_locations(
+            [self.get_mouse_location().coords],
+            self.imglog.hotmaps[-1],
+            30,
+            0,
+            0,
+            0,
+        )
+        name = "imglog%s-1control-%s.png" % (
+            self.imglog.printable_step,
+            self.imglog.type,
+        )
+        self.imglog.dump_hotmap(name, self.imglog.hotmaps[-1])
+
+        self.imglog.clear()
+        ImageLogger.step += 1
 
 
 class AutoPyController(Controller):
@@ -528,6 +560,8 @@ class AutoPyController(Controller):
 
         See base method for details.
         """
+        self.imglog.type = "mouse"
+        self.imglog.log(30)
         button = self._mousemap.LEFT_BUTTON if button is None else button
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
@@ -579,6 +613,8 @@ class AutoPyController(Controller):
 
         See base method for details.
         """
+        self.imglog.type = "keys"
+        self.imglog.log(30)
         time.sleep(self.params["control"]["delay_before_keys"])
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
@@ -752,6 +788,8 @@ class XDoToolController(Controller):
 
         See base method for details.
         """
+        self.imglog.type = "mouse"
+        self.imglog.log(30)
         button = self._mousemap.LEFT_BUTTON if button is None else button
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
@@ -807,6 +845,8 @@ class XDoToolController(Controller):
 
         See base method for details.
         """
+        self.imglog.type = "keys"
+        self.imglog.log(30)
         time.sleep(self.params["control"]["delay_before_keys"])
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
@@ -971,6 +1011,8 @@ class VNCDoToolController(Controller):
 
         See base method for details.
         """
+        self.imglog.type = "mouse"
+        self.imglog.log(30)
         button = self._mousemap.LEFT_BUTTON if button is None else button
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
@@ -1033,6 +1075,8 @@ class VNCDoToolController(Controller):
 
         See base method for details.
         """
+        self.imglog.type = "keys"
+        self.imglog.log(30)
         time.sleep(self.params["control"]["delay_before_keys"])
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
@@ -1184,6 +1228,8 @@ class PyAutoGUIController(Controller):
 
         See base method for details.
         """
+        self.imglog.type = "mouse"
+        self.imglog.log(30)
         button = self._mousemap.LEFT_BUTTON if button is None else button
         if modifiers is not None:
             self.keys_toggle(modifiers, True)
@@ -1253,6 +1299,8 @@ class PyAutoGUIController(Controller):
 
         See base method for details.
         """
+        self.imglog.type = "keys"
+        self.imglog.log(30)
         time.sleep(self.params["control"]["delay_before_keys"])
         if modifiers is not None:
             self.keys_toggle(modifiers, True)

--- a/guibot/finder.py
+++ b/guibot/finder.py
@@ -40,7 +40,6 @@ from .config import GlobalConfig, LocalConfig
 from .imagelogger import ImageLogger
 from .fileresolver import FileResolver
 from .errors import *
-from .location import Location
 
 
 log = logging.getLogger("guibot.finder")
@@ -359,10 +358,6 @@ class Finder(LocalConfig):
             "deep",
             "hybrid",
         ]
-
-        # other attributes
-        self.imglog = ImageLogger()
-        self.imglog.log = self.log
 
         # additional preparation (no synchronization available)
         if configure:
@@ -1771,9 +1766,15 @@ class FeatureFinder(Finder):
             )
             return None
         else:
-            self._log_features(
-                30, self.imglog.locations, self.imglog.hotmaps[-1], 3, 0, 0, 255
-            )
+            if 30 >= self.imglog.logging_level:
+                self.imglog.draw_locations(
+                    self.imglog.locations,
+                    self.imglog.hotmaps[-1],
+                    3,
+                    0,
+                    0,
+                    255,
+                )
             return locations_in_haystack
 
     def _detect_features(
@@ -1837,7 +1838,15 @@ class FeatureFinder(Finder):
             len(hkeypoints),
         )
         hkp_locations = [hkp.pt for hkp in hkeypoints]
-        self._log_features(10, hkp_locations, self.imglog.hotmaps[-4], 3, 255, 0, 0)
+        if 10 >= self.imglog.logging_level:
+            self.imglog.draw_locations(
+                hkp_locations,
+                self.imglog.hotmaps[-4],
+                3,
+                255,
+                0,
+                0,
+            )
 
         return (nkeypoints, ndescriptors, hkeypoints, hdescriptors)
 
@@ -1958,7 +1967,15 @@ class FeatureFinder(Finder):
 
         # these matches are half the way to being good
         mhkp_locations = [mhkp.pt for mhkp in match_hkeypoints]
-        self._log_features(10, mhkp_locations, self.imglog.hotmaps[-3], 2, 255, 255, 0)
+        if 10 >= self.imglog.logging_level:
+            self.imglog.draw_locations(
+                mhkp_locations,
+                self.imglog.hotmaps[-3],
+                2,
+                255,
+                255,
+                0,
+            )
 
         match_similarity = float(len(match_nkeypoints)) / float(len(nkeypoints))
         # update the current achieved similarity if matching similarity is used:
@@ -2035,7 +2052,15 @@ class FeatureFinder(Finder):
             if mask[i][0] == 1:
                 true_matches.append(kp)
         tmhkp_locations = [tmhkp.pt for tmhkp in true_matches]
-        self._log_features(20, tmhkp_locations, self.imglog.hotmaps[-2], 1, 0, 255, 0)
+        if 20 >= self.imglog.logging_level:
+            self.imglog.draw_locations(
+                tmhkp_locations,
+                self.imglog.hotmaps[-2],
+                1,
+                0,
+                255,
+                0,
+            )
 
         # calculate and project all point coordinates in the needle
         projected = []
@@ -2098,24 +2123,6 @@ class FeatureFinder(Finder):
 
         self.imglog.clear()
         ImageLogger.step += 1
-
-    def _log_features(
-        self,
-        lvl: int,
-        locations: list[tuple[float, float]],
-        hotmap: "Matlike",
-        radius: int = 0,
-        r: int = 255,
-        g: int = 255,
-        b: int = 255,
-    ) -> None:
-        if lvl < self.imglog.logging_level:
-            return
-        import cv2
-
-        for loc in locations:
-            x, y = loc
-            cv2.circle(hotmap, (int(x), int(y)), radius, (r, g, b))
 
 
 class CascadeFinder(Finder):

--- a/guibot/imagelogger.py
+++ b/guibot/imagelogger.py
@@ -69,6 +69,8 @@ class ImageLogger(object):
         self.similarities = []
         self.locations = []
 
+        self.type = "find"
+
         # sync these static methods with the general settings at each use
         ImageLogger.logging_level = GlobalConfig.image_logging_level
         # NOTE: the executing code decides when to clean this directory
@@ -84,6 +86,17 @@ class ImageLogger(object):
         return ("%0" + str(ImageLogger.step_width) + "d") % ImageLogger.step
 
     printable_step = property(fget=get_printable_step)
+
+    def log(self, _lvl: int) -> None:
+        """
+        Log images with an arbitrary logging level.
+
+        :param lvl: logging level for the message
+        """
+        raise NotImplementedError(
+            "Each finder or controller that does image logging "
+            "has to implement this itself"
+        )
 
     def debug(self) -> None:
         """Log images with a DEBUG logging level."""
@@ -104,6 +117,31 @@ class ImageLogger(object):
     def critical(self) -> None:
         """Log images with a CRITICAL logging level."""
         self.log(50)
+
+    def draw_locations(
+        self,
+        locations: list[tuple[float, float]],
+        canvas: "Matlike",
+        radius: int = 0,
+        r: int = 255,
+        g: int = 255,
+        b: int = 255,
+    ) -> None:
+        """
+        Draw locations on a canvas image to visualize points of interest.
+
+        :param locations: list of locations to draw
+        :param canvas: canvas image to draw on
+        :param radius: radius for the circled locations
+        :param r: red value for the color of the circles locations
+        :param g: green value for the color of the circles locations
+        :param b: blue value for the color of the circles locations
+        """
+        import cv2
+
+        for loc in locations:
+            x, y = loc
+            cv2.circle(canvas, (int(x), int(y)), radius, (r, g, b))
 
     def dump_matched_images(self) -> None:
         """
@@ -161,3 +199,4 @@ class ImageLogger(object):
         self.hotmaps = []
         self.similarities = []
         self.locations = []
+        self.type = "find"

--- a/guibot/location.py
+++ b/guibot/location.py
@@ -64,3 +64,13 @@ class Location(object):
         return self._ypos
 
     y = property(fget=get_y)
+
+    def get_coords(self) -> tuple[int, int]:
+        """
+        Getter for readonly attributes.
+
+        :returns: tuple of (x, y) coordinates of the location
+        """
+        return self._xpos, self._ypos
+
+    coords = property(fget=get_coords)

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -74,9 +74,9 @@ class FinderTest(unittest.TestCase):
     def _verify_and_get_dumps(self, count: int, index: int = 1, multistep: bool = False) -> list[str]:
         dumps = os.listdir(self.logpath)
         self.assertEqual(len(dumps), count)
-        steps = self._get_matches_in('imglog\d\d\d\d-.+', dumps)
+        steps = self._get_matches_in(r'imglog\d\d\d\d-.+', dumps)
         self.assertEqual(len(steps), len(dumps))
-        first_steps = self._get_matches_in('imglog%04d-.+' % index, dumps)
+        first_steps = self._get_matches_in(r'imglog%04d-.+' % index, dumps)
         if not multistep:
             self.assertEqual(len(first_steps), len(steps))
         else:
@@ -118,7 +118,7 @@ class FinderTest(unittest.TestCase):
         self.assertEqual(len(hotmaps), 1)
         self.assertIn('3hotmap', hotmaps[0])
         # report achieved similarity in the end of the filename
-        self.assertRegex(hotmaps[0], ".*-\d\.\d+.*")
+        self.assertRegex(hotmaps[0], r".*-\d\.\d+.*")
         self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmaps[0])))
 
     @unittest.skipIf(os.environ.get('DISABLE_OPENCV', "0") == "1", "OpenCV disabled")
@@ -242,7 +242,7 @@ class FinderTest(unittest.TestCase):
                 self.assertEqual(len(hotmaps), 3)
                 self.assertIn('3hotmap', hotmaps[0])
                 # report achieved similarity in the end of the filename
-                self.assertRegex(hotmaps[0], ".*-\d\.\d+.*")
+                self.assertRegex(hotmaps[0], r".*-\d\.\d+.*")
                 self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmaps[0])))
                 self.assertIn('3hotmap-1threshold', hotmaps[1])
                 self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmaps[1])))
@@ -276,7 +276,7 @@ class FinderTest(unittest.TestCase):
                 self.assertEqual(len(hotmaps), 3)
                 self.assertIn('3hotmap', hotmaps[0])
                 # report achieved similarity in the end of the filename
-                self.assertRegex(hotmaps[0], ".*-\d\.\d+.*")
+                self.assertRegex(hotmaps[0], r".*-\d\.\d+.*")
                 self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmaps[0])))
                 self.assertIn('3hotmap-1threshold', hotmaps[1])
                 self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmaps[1])))
@@ -318,7 +318,7 @@ class FinderTest(unittest.TestCase):
                 else:
                     self.assertIn('3hotmap-1template', hotmap)
                 # report achieved similarity in the end of the filename
-                self.assertRegex(hotmap, ".*-\d\.\d+.*")
+                self.assertRegex(hotmap, r".*-\d\.\d+.*")
                 self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmap)))
 
             shutil.rmtree(self.logpath)
@@ -352,7 +352,7 @@ class FinderTest(unittest.TestCase):
                 else:
                     self.assertIn('3hotmap-1template', hotmap)
                 # report achieved similarity in the end of the filename
-                self.assertRegex(hotmap, ".*-\d\.\d+.*")
+                self.assertRegex(hotmap, r".*-\d\.\d+.*")
                 self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmap)))
 
             shutil.rmtree(self.logpath)
@@ -395,7 +395,7 @@ class FinderTest(unittest.TestCase):
             else:
                 self.assertIn('3hotmap-%stemplate' % i, hotmap)
             # report achieved similarity in the end of the filename
-            self.assertRegex(hotmap, ".*-\d\.\d+.*")
+            self.assertRegex(hotmap, r".*-\d\.\d+.*")
             self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmap)))
 
     @unittest.skipIf(os.environ.get('DISABLE_OPENCV', "0") == "1", "OpenCV disabled")
@@ -434,7 +434,7 @@ class FinderTest(unittest.TestCase):
                         self.assertEqual(len(hotmaps), 4)
                         self.assertIn('3hotmap', hotmaps[0])
                         # report achieved similarity in the end of the filename
-                        self.assertRegex(hotmaps[0], ".*-\d\.\d+.*")
+                        self.assertRegex(hotmaps[0], r".*-\d\.\d+.*")
                         self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmaps[0])))
                         self.assertIn('3hotmap-1detect', hotmaps[1])
                         self.assertIn('3hotmap-2match', hotmaps[2])
@@ -475,7 +475,7 @@ class FinderTest(unittest.TestCase):
                         self.assertEqual(len(hotmaps), 4)
                         self.assertIn('3hotmap', hotmaps[0])
                         # report achieved similarity in the end of the filename
-                        self.assertRegex(hotmaps[0], ".*-\d\.\d+.*")
+                        self.assertRegex(hotmaps[0], r".*-\d\.\d+.*")
                         self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmaps[0])))
                         self.assertIn('3hotmap-1detect', hotmaps[1])
                         self.assertIn('3hotmap-2match', hotmaps[2])
@@ -664,7 +664,7 @@ class FinderTest(unittest.TestCase):
                         self.assertIn('3hotmap-3ocr-%stext' % (j-2), hotmap)
                     if j == 3 or j == 4:
                         # report achieved similarity in the end of the filename
-                        self.assertRegex(hotmap, ".*-\d\.\d+.*")
+                        self.assertRegex(hotmap, r".*-\d\.\d+.*")
                     self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmap)))
 
                 shutil.rmtree(self.logpath)
@@ -724,7 +724,7 @@ class FinderTest(unittest.TestCase):
                         self.assertIn('3hotmap-3ocr-%stext' % (j-2), hotmap)
                     if j == 3 or j == 4:
                         # report achieved similarity in the end of the filename
-                        self.assertRegex(hotmap, ".*-\d\.\d+.*")
+                        self.assertRegex(hotmap, r".*-\d\.\d+.*")
                     self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmap)))
 
                 shutil.rmtree(self.logpath)
@@ -830,7 +830,7 @@ class FinderTest(unittest.TestCase):
                 else:
                     self.assertIn('%itemplate' % int((i - 1) / 2 + 1), hotmap)
                 # report achieved similarity in the end of the filename
-                self.assertRegex(hotmap, ".*-\d\.\d+.*")
+                self.assertRegex(hotmap, r".*-\d\.\d+.*")
                 self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmap)))
 
             shutil.rmtree(self.logpath)
@@ -860,7 +860,7 @@ class FinderTest(unittest.TestCase):
             self.assertNotIn('template', hotmap)
             self.assertNotIn('feature', hotmap)
             # report achieved similarity in the end of the filename
-            self.assertRegex(hotmap, ".*-\d\.\d+.*")
+            self.assertRegex(hotmap, r".*-\d\.\d+.*")
             self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmap)))
 
             shutil.rmtree(self.logpath)
@@ -890,7 +890,7 @@ class FinderTest(unittest.TestCase):
             if i == 0:
                 self.assertIn('3hotmap', hotmap)
                 # report achieved similarity in the end of the filename
-                self.assertRegex(hotmap, ".*-\d\.\d+.*")
+                self.assertRegex(hotmap, r".*-\d\.\d+.*")
             else:
                 self.assertIn('%sf' % i, hotmap)
             self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmap)))
@@ -920,7 +920,7 @@ class FinderTest(unittest.TestCase):
             if i == 0:
                 self.assertIn('3hotmap', hotmap)
                 # report achieved similarity in the end of the filename
-                self.assertRegex(hotmap, ".*-\d\.\d+.*")
+                self.assertRegex(hotmap, r".*-\d\.\d+.*")
             else:
                 self.assertIn('%sf' % i, hotmap)
             self.assertTrue(os.path.isfile(os.path.join(self.logpath, hotmap)))

--- a/tests/test_imagelogger.py
+++ b/tests/test_imagelogger.py
@@ -54,6 +54,11 @@ class ImageLoggerTest(unittest.TestCase):
         self._patch_mkdir.stop()
         return super().tearDown()
 
+    def test_abstract_log(self) -> None:
+        """Test the main log method requires implementation."""
+        with self.assertRaises(NotImplementedError):
+            self.imglog.log(10)
+
     def test_step_print(self) -> None:
         """Test the string representation of the current step."""
         for i in range(1, 10):


### PR DESCRIPTION
To draw the current mouse location while either clicking or while indicating focus during typing we generalize previous location drawing functionality to the image logger class and retrieve a coordinates tuple from the location class.