### PR TITLE
Add CI for auto release and push artifacts with it (.rpm and .deb)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,36 @@ jobs:
           verbose: true
         if: matrix.install_variant == 'pip'
       - run: echo "🥑 This job's status is ${{ job.status }}."
+
+      # Publish release:
+      - name: Set Release Variables
+        id: set_vars
+        run: |
+          CHANGELOG_REVS=($(sed -n -e 's/^guibot[ \t]*(\([0-9]*.[0-9]*\)-[0-9]*).*/\1/p' "/home/runner/work/guibot/guibot/packaging/debian/changelog"))
+          VERSION=${CHANGELOG_REVS[0]}
+          echo "version=$VERSION" >> $GITHUB_ENV
+          if [[ "${{ matrix.install_variant }}" == "rpm.fedora.40" ]]; then
+              EXTENSION="rpm"
+              EXE_NAME="guibot"
+          else
+              EXTENSION="deb"
+              EXE_NAME="python3-guibot"
+          fi
+          echo "ext=$EXTENSION" >> $GITHUB_ENV
+          echo "name=$EXE_NAME" >> $GITHUB_ENV
+        if: matrix.install_variant != 'pip'
+
+      - name: Create Release and Push Artifacts
+        uses: ncipollo/release-action@v1.14.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: 'guibot ${{ env.version }}'
+          tag: "${{ env.version }}"
+          body: 'Auto generated release builds'
+          artifacts: '/home/runner/work/guibot/guibot/${{ env.name }}_${{ env.version }}.${{ env.ext }}'
+          updateOnlyUnreleased: 'false'
+          allowUpdates: 'true'
+          prerelease: 'false'
+          makeLatest: 'true'
+        if: matrix.install_variant != 'pip'

--- a/packaging/packager_deb.sh
+++ b/packaging/packager_deb.sh
@@ -66,7 +66,17 @@ cd "$distro_root/$NAME-$VERSION/packaging"
 debuild --no-tgz-check --no-lintian -i -us -uc -b
 cp ../${NAME}_${VERSION}*.deb "$distro_root/guibot"
 apt-get -y install "$distro_root/guibot/"${NAME}_${VERSION}*.deb
-rm -fr "$distro_root/$NAME-$VERSION"
+
+# Find the .deb file in $distro_root
+deb_file=$(find "$distro_root/guibot" -type f -name "*.deb" | head -n 1)
+# Check if the file exists
+if [[ -z "$deb_file" ]]; then
+  echo "Error: No .deb file found in $distro_root"
+  exit 1
+fi
+# Rename the found file
+new_file="$distro_root/guibot/${NAME}_${VERSION}.deb"
+mv "$deb_file" "$new_file"
 
 echo "------------- virtual display -------------"
 apt-get -y install xvfb vim-common

--- a/packaging/packager_rpm.sh
+++ b/packaging/packager_rpm.sh
@@ -51,7 +51,17 @@ tar czvf ~/rpmbuild/SOURCES/$NAME-$VERSION.tar.gz -C "$distro_root/" --exclude=.
 rpmbuild -ba "$distro_root/$NAME-$VERSION/packaging/guibot.spec" --with opencv
 cp ~/rpmbuild/RPMS/x86_64/python3-$NAME-$VERSION*.rpm "$distro_root/guibot"
 dnf -y install "$distro_root/guibot/python3-"$NAME-$VERSION*.rpm
-rm -fr "$distro_root/$NAME-$VERSION"
+
+# Find the .rpm file in $distro_root
+rpm_file=$(find "$distro_root/guibot" -type f -name "*.rpm" | head -n 1)
+# Check if the file exists
+if [[ -z "$rpm_file" ]]; then
+  echo "Error: No .rpm file found in $distro_root"
+  exit 1
+fi
+# Rename the found file
+new_file="$distro_root/guibot/${NAME}_${VERSION}.rpm"
+mv "$rpm_file" "$new_file"
 
 echo "------------- virtual display -------------"
 dnf install -y xorg-x11-server-Xvfb vim-common


### PR DESCRIPTION
This commit adds a new CI job to push artifacts and generate a new release on every update we make. It will make the process after running unit tests so that we can guarantee a safe artifact for the final user with our latest changes. It was needed to change a few small things on the packagers (deb and rpm) so that we keep the artifacts after installing them on the docker containers.