### PR TITLE
Restore AutoPy 4.0.1 as default display controller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,6 @@ jobs:
           sleep 3
       - name: Run current semi-isolation semi-integration tests (to be separated in the future)
         run: |
-          if [[ "${{ matrix.python-version }}" == "3.10.8" ]]; then export DISABLE_AUTOPY=1; fi
-          if [[ "${{ matrix.python-version }}" == "3.11" ]]; then export DISABLE_AUTOPY=1; fi
-          if [[ "${{ matrix.python-version }}" == "3.12" ]]; then export DISABLE_AUTOPY=1; fi
           if [[ "${{ matrix.install_variant }}" != "pip" ]]; then cd packaging && bash packager_docker.sh;
           else cd tests && bash coverage_analysis.sh; fi
         env:

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Supported Computer Vision (CV) backends are based on
     - Text matching through pytesseract, tesserocr, or OpenCV's bindings
 - [PyTorch](https://github.com/pytorch/pytorch)
     - R-CNN matching through Faster R-CNN or Mask R-CNN
-- [autopy](https://github.com/msanders/autopy)
+- [autopy](https://github.com/autopilot-rs/autopy)
     - AutoPy matching
 
 Supported Display Controller (DC) backends are based on
 
+- [AutoPy](https://github.com/autopilot-rs/autopy)
 - [PyAutoGUI](https://github.com/asweigart/pyautogui)
-- [AutoPy](https://github.com/msanders/autopy)
 - [VNCDoTool](https://github.com/sibson/vncdotool)
 - [XDoTool](https://www.semicomplete.com/projects/xdotool)
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -64,14 +64,14 @@ Supported Computer Vision (CV) backends are based on
 
    -  R-CNN matching through Faster R-CNN or Mask R-CNN
 
--  `autopy <https://github.com/msanders/autopy>`__
+-  `autopy <https://github.com/autopilot-rs/autopy>`__
 
    -  AutoPy matching
 
 Supported Display Controller (DC) backends are based on
 
+-  `AutoPy <https://github.com/autopilot-rs/autopy>`__
 -  `PyAutoGUI <https://github.com/asweigart/pyautogui>`__
--  `AutoPy <https://github.com/msanders/autopy>`__
 -  `VNCDoTool <https://github.com/sibson/vncdotool>`__
 -  `XDoTool <https://www.semicomplete.com/projects/xdotool>`__
 

--- a/guibot/config.py
+++ b/guibot/config.py
@@ -64,7 +64,7 @@ class GlobalConfig(type):
     _image_quality = 3
 
     # backends shared between all instances
-    _display_control_backend = "pyautogui"
+    _display_control_backend = "autopy"
     _find_backend = "hybrid"
     _contour_threshold_backend = "adaptive"
     _template_match_backend = "ccoeff_normed"
@@ -299,10 +299,10 @@ class GlobalConfig(type):
         :raises: :py:class:`ValueError` if value is not among the supported backends
 
         Supported backends:
-           * pyautogui - Windows, Linux, and OS X compatible with both the GUI
-                         actions and their calls executed on the same machine
            * autopy - Windows, Linux, and OS X compatible with both the GUI
                       actions and their calls executed on the same machine.
+           * pyautogui - Windows, Linux, and OS X compatible with both the GUI
+                         actions and their calls executed on the same machine
            * vncdotool - guest OS independent or Linux remote OS with GUI
                          actions on a remote machine through vnc and their
                          calls on a vnc client machine.

--- a/guibot/controller.py
+++ b/guibot/controller.py
@@ -403,7 +403,7 @@ class AutoPyController(Controller):
     """
     Screen control backend implemented through AutoPy.
 
-    AutoPy is a small python library portable to Windows and Linux operating systems.
+    AutoPy is a python library portable to Windows, Linux, and MacOS operating systems.
     """
 
     def __init__(self, configure: bool = True, synchronize: bool = True) -> None:

--- a/packaging/packager_docker.sh
+++ b/packaging/packager_docker.sh
@@ -7,12 +7,12 @@ readonly version=$(echo $install_variant | cut -d '.' -f 3)
 
 if [ "$packager" == "rpm" ]; then
     sudo docker run \
-            -e DISTRO="$distro" -e VERSION="$version" -e ROOT="/" -e DISABLE_AUTOPY="1" \
+            -e DISTRO="$distro" -e VERSION="$version" -e ROOT="/" \
             -v $(pwd)/..:/guibot:rw $distro:$version \
             /bin/bash /guibot/packaging/packager_rpm.sh
 elif [ "$packager" == "deb" ]; then
     sudo docker run \
-            -e DISTRO="$distro" -e VERSION="$version" -e ROOT="/" -e DISABLE_AUTOPY="1" \
+            -e DISTRO="$distro" -e VERSION="$version" -e ROOT="/" \
             -v $(pwd)/..:/guibot:rw $distro:$version \
             /bin/bash /guibot/packaging/packager_deb.sh
 fi

--- a/packaging/packager_pip.sh
+++ b/packaging/packager_pip.sh
@@ -10,12 +10,6 @@ readonly distro_root="${ROOT:-$HOME}"
 readonly python_version="${PYTHON_VERSION:-3.8}"
 readonly release_tag="${RELEASE_TAG:-}"
 
-# disable tests and support of backends based on python versions
-if [[ $python_version == '3.9' ]]; then export DISABLE_AUTOPY=1; fi
-if [[ $python_version == '3.10.8' ]]; then export DISABLE_AUTOPY=1; fi
-if [[ $python_version == '3.11' ]]; then export DISABLE_AUTOPY=1; fi
-if [[ $python_version == '3.12' ]]; then export DISABLE_AUTOPY=1; fi
-
 # environment dependencies not provided by pip
 # python3
 if [[ $python_version == '3.9' ]]; then dnf -y install python39 python39-devel; fi

--- a/packaging/packager_win.bat
+++ b/packaging/packager_win.bat
@@ -2,8 +2,6 @@ SET DISTRO="windows"
 SET DISTRO_VERSION="10"
 SET DISTRO_ROOT="%HOMEDRIVE%"
 
-REM AutoPy is not available for Python3.9 at present
-SET DISABLE_AUTOPY=1
 REM Tesseract doesn't have original installers for Windows
 SET DISABLE_OCR=1
 REM Drag/drop with the current default DC backend is not supported on Windows

--- a/packaging/pip_requirements.txt
+++ b/packaging/pip_requirements.txt
@@ -3,7 +3,7 @@ Pillow==9.3.0; python_version < '3.12'
 Pillow==10.3.0; python_version >= '3.12'
 
 # backends
-autopy==4.0.0; python_version <= '3.8' and platform_python_implementation != "PyPy"
+autopy==4.0.1; python_version >= '3.8' and platform_python_implementation != "PyPy"
 # OCR is currently not tested on Windows due to custom Tesseract OCR installers
 pytesseract==0.3.13; sys_platform != 'win32'
 tesserocr==2.7.1; sys_platform != 'win32'

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -1008,7 +1008,6 @@ class FinderTest(unittest.TestCase):
     def test_hybrid_multiconfig(self) -> None:
         """Test hybrid matching with multiple chain configs."""
         finder = HybridFinder()
-        # TOOD: replace autopy to improve coverage across variants
         finder.configure_backend("autopy")
         finder.synchronize_backend("autopy")
         finder.params["find"]["similarity"].value = 1.0

--- a/tests/test_region_calc.py
+++ b/tests/test_region_calc.py
@@ -19,7 +19,7 @@ import unittest
 
 import common_test
 from guibot.region import Region
-from guibot.controller import Controller, PyAutoGUIController
+from guibot.controller import Controller, AutoPyController
 
 
 @unittest.skipIf(os.environ.get('DISABLE_PYAUTOGUI', "0") == "1", "PyAutoGUI disabled")
@@ -27,7 +27,7 @@ class RegionTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
-        cls.screen = PyAutoGUIController()
+        cls.screen = AutoPyController()
 
     def test_position_calc(self) -> None:
         region = Region(10, 20, 300, 200)

--- a/tests/test_region_expect.py
+++ b/tests/test_region_expect.py
@@ -30,7 +30,7 @@ from guibot.match import Match
 from guibot.target import Image, Text
 from guibot.inputmap import Key
 from guibot.finder import AutoPyFinder, TemplateFinder, TextFinder
-from guibot.controller import PyAutoGUIController
+from guibot.controller import AutoPyController
 from guibot.errors import *
 
 
@@ -104,10 +104,10 @@ class RegionTest(unittest.TestCase):
 
             time.sleep(0.2)
 
-    @unittest.skipIf(os.environ.get('DISABLE_PYAUTOGUI', "0") == "1", "PyAutoGUI disabled")
+    @unittest.skipIf(os.environ.get('DISABLE_AUTOPY', "0") == "1", "AutoPy disabled")
     def test_initialize(self) -> None:
-        screen_width = PyAutoGUIController().width
-        screen_height = PyAutoGUIController().height
+        screen_width = AutoPyController().width
+        screen_height = AutoPyController().height
 
         self.assertEqual(0, self.region.x)
         self.assertEqual(0, self.region.y)


### PR DESCRIPTION
Make complete use of the revived release 4.0.1 which is now also maintained by some of Guibot project's maintainers and thus could be better integrated for use as guibot dependency.