### PR TITLE
Fix missing test skip if PyQt is disabled

### DIFF
--- a/tests/test_region_control.py
+++ b/tests/test_region_control.py
@@ -361,6 +361,7 @@ class RegionTest(unittest.TestCase):
         self.assertEqual(0, self.wait_end(self.child_app))
         self.child_app = None
 
+    @unittest.skipIf(os.environ.get('DISABLE_PYQT', "0") == "1", "PyQt disabled")
     def test_select_at(self) -> None:
         # NOTE: autopy has a bug with arrow keys which would result in a fatal error
         # here breaking the entire run


### PR DESCRIPTION
Small fix by adding a flag to skip the test_select_at test if pyqt is disabled.