### PR TITLE
Python 3.14 clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,4 @@
 
-yaml
-
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,35 @@
+
+yaml
+
 name: CI
 
 on:
-  push:
-  pull_request:
-  workflow_dispatch:
+ push:
+   branches: [ main, master ]
+ pull_request:
+   branches: [ main, master ]
 
 jobs:
+ build:
+   runs-on: ubuntu-latest
+   strategy:
+    matrix:
+     python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+
+
+  steps:
+  -uses: actions/checkout@v4
+  -name: Set up Python ${{ matrix.python-version }}
+   uses: actions/setup-python@v5
+   with:
+     python-version: ${{ matrix.python-version }}
+  -name: Install dependencies
+   run: |
+     python -m pip install --upgrade pip
+     pip install pytest
+  -name: Test with pytest
+   run: |
+     pytest
 
   linux-multi-python:
     name: Linux ${{ matrix.install_variant }} with Python ${{ matrix.python-version }}
@@ -218,3 +242,4 @@ jobs:
           DISABLE_VNCDOTOOL: 1
           # TODO: enable PyAutoGUI for macOS if there is more interest
           DISABLE_PYAUTOGUI: 1
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ['3.12', '3.13']
+          python-version: '3.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
-
+          python-version: ['3.12', '3.13']
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+
+
 # Guibot [![GH Actions](https://github.com/intra2net/guibot/actions/workflows/ci.yml/badge.svg)](https://github.com/intra2net/guibot/actions/workflows/ci.yml) [![Documentation Status](https://readthedocs.org/projects/guibot/badge/?version=latest)](http://guibot.readthedocs.io/en/latest/?badge=latest) [![CodeQL](https://github.com/intra2net/guibot/actions/workflows/codeql.yml/badge.svg)](https://github.com/intra2net/guibot/actions/workflows/codeql.yml) [![codecov](https://codecov.io/gh/intra2net/guibot/branch/master/graph/badge.svg)](https://codecov.io/gh/intra2net/guibot) [![black](https://img.shields.io/badge/black-000000.svg?logo=black&label=code%20style)](https://github.com/psf/black) [![PyPI](https://img.shields.io/pypi/v/guibot?logo=pypi&label=PyPI)](https://pypi.org/project/guibot/)
 
 A tool for GUI automation using a variety of computer vision and display control backends.
@@ -38,6 +40,8 @@ Supported Display Controller (DC) backends are based on
 
 ## Further resources
 
+
+
 Homepage: http://guibot.org
 
 Documentation: http://guibot.readthedocs.io
@@ -47,3 +51,4 @@ Installation: https://github.com/intra2net/guibot/wiki/Packaging
 Issue tracking: https://github.com/intra2net/guibot/issues
 
 Project wiki: https://github.com/intra2net/guibot/wiki
+


### PR DESCRIPTION
Added support for Python 3.14 to the CI workflow and fixed the formatting issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI now runs the test suite across Python 3.10–3.14.
  * CI triggers are limited to changes targeting the main branches.

* **Chores**
  * Lint checks now run against Python 3.12 and 3.13.
  * Updated README formatting for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->