### PR TITLE
Fix python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.10.8, 3.11, 3.12, 3.13]
+        python-version: ['3.x']
         install_variant: ["pip"]
         include:
-          - python-version: 3.12
+          - python-version: '3.x'
             install_variant: "rpm.fedora.40"
-          - python-version: 3.12
+          - python-version: '3.x'
             install_variant: "deb.ubuntu.noble"
       fail-fast: false
 
@@ -125,7 +125,7 @@ jobs:
         with:
           name: '${{ env.artifact_name }}'
           path: '${{ env.artifact_full_path }}'
-        if: matrix.install_variant != 'pip' || matrix.python-version == 3.13
+        if: matrix.install_variant != 'pip' || matrix.python-version == '3.x'
 
   windows:
     name: Windows with any available coverage
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.x'
           cache: 'pip'
           cache-dependency-path: 'packaging/pip_requirements.txt'
       - name: Local pip installation on Windows
@@ -183,7 +183,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.x'
           cache: 'pip'
           cache-dependency-path: 'packaging/pip_requirements.txt'
       - name: Install non-python dependencies using system packager

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           name: '${{ env.artifact_name }}'
           path: '${{ env.artifact_full_path }}'
-        if: matrix.install_variant != 'pip' || matrix.python-version == 3.13
+        if: matrix.install_variant != 'pip' || matrix.python-version == 3.13 || matrix.python-version ==3.14
 
   windows:
     name: Windows with any available coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.x']
+        python-version: [3.10.8, 3.11, 3.12, 3.13]
         install_variant: ["pip"]
         include:
-          - python-version: '3.x'
+          - python-version: 3.12
             install_variant: "rpm.fedora.40"
-          - python-version: '3.x'
+          - python-version: 3.12
             install_variant: "deb.ubuntu.noble"
       fail-fast: false
 
@@ -125,7 +125,7 @@ jobs:
         with:
           name: '${{ env.artifact_name }}'
           path: '${{ env.artifact_full_path }}'
-        if: matrix.install_variant != 'pip' || matrix.python-version == '3.x'
+        if: matrix.install_variant != 'pip' || matrix.python-version == 3.13
 
   windows:
     name: Windows with any available coverage
@@ -138,7 +138,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'packaging/pip_requirements.txt'
       - name: Local pip installation on Windows
@@ -183,7 +183,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'packaging/pip_requirements.txt'
       - name: Install non-python dependencies using system packager

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.10.8, 3.11, 3.12, 3.13]
+        python-version: ['3.10.8', '3.11', '3.12', '3.13', '3.14']
         install_variant: ["pip"]
         include:
           - python-version: 3.12


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded the Linux CI test matrix to include **Python 3.14**, increasing automated test coverage across newer Python releases.
  * Updated CI artifact upload conditions to ensure artifacts are produced for **Python 3.14** runs as well.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->