### PR TITLE
Fix env placement bugs in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         pushd packaging
         python3 setup.py sdist bdist_wheel
         popd
-        if: matrix.install_variant == 'pip'
+      if: matrix.install_variant == 'pip'
     - run: sleep 3
     - name: Cache large ML models
       uses: actions/cache@v4
@@ -124,7 +124,7 @@ jobs:
          name: '${{ env.artifact_name }}'
          path: '${{ env.artifact_full_path }}'
          
-      if: matrix.install_variant != 'pip' || matrix.python-version == 3.13
+     if: matrix.install_variant != 'pip' || matrix.python-version == 3.13
   
   windows:
     name: Windows with any available coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-      cache-dependency-path: 'packaging/pip_requirements.txt'
       if: matrix.install_variant == 'pip'
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
@@ -139,8 +137,6 @@ windows:
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
-        cache: 'pip'
-        cache-dependency-path: 'packaging/pip_requirements.txt'
     - name: Local pip installation on Windows
       run: |
         cd packaging
@@ -184,8 +180,6 @@ macos:
       uses: actions/setup-python@v5
       with:
       python-version: '3.12'
-      cache: 'pip'
-      cache-dependency-path: 'packaging/pip_requirements.txt'
     - name: Install non-python dependencies using system packager
       run: |
         # ocr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,12 +78,12 @@ jobs:
         # give xvfb some time to start
         sleep 3
     - name: Run current semi-isolation semi-integration tests (to be separated in the future)
+      env:
+        INSTALL_VARIANT: ${{ matrix.install_variant }}
+        TESSDATA_PREFIX: /usr/share/tesseract-ocr/5/tessdata
       run: |
         if [[ "${{ matrix.install_variant }}" != "pip" ]]; then cd packaging && bash packager_docker.sh;
         else cd tests && bash coverage_analysis.sh; fi
-        env:
-        INSTALL_VARIANT: ${{ matrix.install_variant }}
-        TESSDATA_PREFIX: /usr/share/tesseract-ocr/5/tessdata
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,8 +195,8 @@ jobs:
           DISABLE_XDOTOOL: 1
           # requires VNC server and thus only available on Linux
           DISABLE_VNCDOTOOL: 1
+          # TODO: enable PyAutoGUI for macOS if there is more interest
+          DISABLE_PYAUTOGUI: 1
       run: |
           cd tests
           bash coverage_analysis.sh 
-        # TODO: enable PyAutoGUI for macOS if there is more interest
-        DISABLE_PYAUTOGUI: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   linux-multi-python:
     name: Linux ${{ matrix.install_variant }} with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,14 +121,15 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: '${{ env.artifact_name }}'
-        path: '${{ env.artifact_full_path }}'
+         name: '${{ env.artifact_name }}'
+         path: '${{ env.artifact_full_path }}'
+         
       if: matrix.install_variant != 'pip' || matrix.python-version == 3.13
-
-windows:
-  name: Windows with any available coverage
-  runs-on: windows-latest
-  steps:
+  
+  windows:
+    name: Windows with any available coverage
+    runs-on: windows-latest
+    steps:
     - name: Check out repository code
       uses: actions/checkout@v4
       with:
@@ -166,12 +167,12 @@ windows:
         # requires VNC server and thus only available on Linux
         DISABLE_VNCDOTOOL: 1
 
-macos:
-  name: MacOS with any available coverage
-  # TODO: downgrade from "latest" to 14 due to MacOS 15 suddenly failing a lot of tests
-  # -> should be lifted once we add image logging artifacts to easily debug CI environment
-  runs-on: macos-14
-  steps:
+  macos:
+    name: MacOS with any available coverage
+    # TODO: downgrade from "latest" to 14 due to MacOS 15 suddenly failing a lot of tests
+    # -> should be lifted once we add image logging artifacts to easily debug CI environment
+    runs-on: macos-14
+    steps:
     - name: Check out repository code
       uses: actions/checkout@v4
       with:
@@ -179,7 +180,7 @@ macos:
     - name: Set up Python 3
       uses: actions/setup-python@v5
       with:
-      python-version: '3.12'
+        python-version: '3.12'
     - name: Install non-python dependencies using system packager
       run: |
         # ocr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,7 @@ jobs:
         pip install wxPython==4.2.4
         python -c "import wx; app = wx.App(); display = wx.Display()"
     - name: Run current semi-isolation semi-integration tests (to be separated in the future)
-      run: |
-        cd tests
-        bash coverage_analysis.sh
-        env:
+      env:
         # tesseract doesn't have original installers for Windows
         DISABLE_OCR: 1
         # drag/drop and in particular drop has problems with AutoPy on Windows
@@ -154,7 +151,9 @@ jobs:
         DISABLE_XDOTOOL: 1
         # requires VNC server and thus only available on Linux
         DISABLE_VNCDOTOOL: 1
-
+      run: |
+        cd tests
+        bash coverage_analysis.sh
   macos:
     name: MacOS with any available coverage
     # TODO: downgrade from "latest" to 14 due to MacOS 15 suddenly failing a lot of tests
@@ -189,15 +188,15 @@ jobs:
         pip install wxPython==4.2.4
         python -c "import wx; app = wx.App(); display = wx.Display()"
     - name: Run current semi-isolation semi-integration tests (to be separated in the future)
+      env:
+          # drag/drop and in particular drop has problems with AutoPy on macOS
+          DISABLE_DRAG: 1
+          # requires X server and thus only available on Linux
+          DISABLE_XDOTOOL: 1
+          # requires VNC server and thus only available on Linux
+          DISABLE_VNCDOTOOL: 1
       run: |
-        cd tests
-        bash coverage_analysis.sh
-        env:
-        # drag/drop and in particular drop has problems with AutoPy on macOS
-        DISABLE_DRAG: 1
-        # requires X server and thus only available on Linux
-        DISABLE_XDOTOOL: 1
-        # requires VNC server and thus only available on Linux
-        DISABLE_VNCDOTOOL: 1
+          cd tests
+          bash coverage_analysis.sh 
         # TODO: enable PyAutoGUI for macOS if there is more interest
         DISABLE_PYAUTOGUI: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,6 @@ jobs:
          name: '${{ env.artifact_name }}'
          path: '${{ env.artifact_full_path }}'
          
-     if: matrix.install_variant != 'pip' || matrix.python-version == 3.13
-  
   windows:
     name: Windows with any available coverage
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,18 +101,9 @@ jobs:
         # Get the part after the last dot    "1" for example
         suffix=${VERSION##*.}
         # Combine them with a hyphen         "0.51.1" -> "0.51-1"
-        VERSION_HYPHEN="${prefix}-${suffix}"   
-        if [[ "$(echo ${{ matrix.install_variant }} | cut -d '.' -f 2)" == "fedora" ]]; then
-        readonly variant_version=$(echo ${{ matrix.install_variant }} | cut -d '.' -f 3)
-        PACKAGE_NAME="python3-guibot-${VERSION_HYPHEN}.fc${variant_version}.x86_64.rpm"
-        PACKAGE_PATH="/home/runner/work/guibot/guibot/${PACKAGE_NAME}"
-        elif [[ "${{ matrix.install_variant }}" == "pip" ]]; then
+        VERSION_HYPHEN="${prefix}-${suffix}"
         PACKAGE_NAME="guibot-${VERSION}-py3-none-any.whl"
         PACKAGE_PATH="/home/runner/work/guibot/guibot/packaging/dist/${PACKAGE_NAME}"
-        else
-        PACKAGE_NAME="python3-guibot_${VERSION_HYPHEN}_all.deb"
-        PACKAGE_PATH="/home/runner/work/guibot/guibot/${PACKAGE_NAME}"
-        fi
         echo "artifact_name=$PACKAGE_NAME" >> $GITHUB_ENV
         echo "artifact_full_path=$PACKAGE_PATH" >> $GITHUB_ENV
     - name: Upload Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.10.8, 3.11, 3.12, 3.13]
-        install_variant: ["pip"]
-        include:
+          python-version: [3.10.8, 3.11, 3.12, 3.13]
+          install_variant: ["pip"]
+          include:
           - python-version: 3.12
             install_variant: "rpm.fedora.40"
           - python-version: 3.12
@@ -25,196 +25,196 @@ jobs:
       fail-fast: false
 
     steps:
-      - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
-      - name: Check out repository code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: 'packaging/pip_requirements.txt'
+    - run: echo "Job triggered by a ${{ github.event_name }} event on branch is ${{ github.ref }} in repository is ${{ github.repository }}, runner on ${{ runner.os }}"
+    - name: Check out repository code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+      cache-dependency-path: 'packaging/pip_requirements.txt'
+      if: matrix.install_variant == 'pip'
+    - name: Display Python version
+      run: python -c "import sys; print(sys.version)"
+      if: matrix.install_variant == 'pip'
+    - name: Refresh system packager mirrors and packages
+      run: sudo apt-get -y update
+    - name: Install non-python dependencies using system packager
+      run: |
+        # ocr
+        sudo apt-get -y install pkg-config tesseract-ocr libtesseract-dev
+        # xdotool
+        sudo apt-get -y install xdotool x11-apps imagemagick
+        # vncdotool
+        sudo apt-get -y install xfonts-base x11vnc
+        # pyautogui
+        sudo apt-get -y install gnome-screenshot
+        # pyqt6 for integration testing
+        sudo apt-get install libegl1 libxcb-cursor0
+      if: matrix.install_variant == 'pip'
+    - name: Install any dependencies and build the package
+      run: |
+        pip --default-timeout=60 install -r packaging/pip_requirements.txt
+        # build tools
+        pip install wheel twine
+        pushd packaging
+        python3 setup.py sdist bdist_wheel
+        popd
         if: matrix.install_variant == 'pip'
-      - name: Display Python version
-        run: python -c "import sys; print(sys.version)"
-        if: matrix.install_variant == 'pip'
-      - name: Refresh system packager mirrors and packages
-        run: sudo apt-get -y update
-      - name: Install non-python dependencies using system packager
-        run: |
-          # ocr
-          sudo apt-get -y install pkg-config tesseract-ocr libtesseract-dev
-          # xdotool
-          sudo apt-get -y install xdotool x11-apps imagemagick
-          # vncdotool
-          sudo apt-get -y install xfonts-base x11vnc
-          # pyautogui
-          sudo apt-get -y install gnome-screenshot
-          # pyqt6 for integration testing
-          sudo apt-get install libegl1 libxcb-cursor0
-        if: matrix.install_variant == 'pip'
-      - name: Install any dependencies and build the package
-        run: |
-          pip --default-timeout=60 install -r packaging/pip_requirements.txt
-          # build tools
-          pip install wheel twine
-          pushd packaging
-          python3 setup.py sdist bdist_wheel
-          popd
-        if: matrix.install_variant == 'pip'
-      - run: sleep 3
-      - name: Cache large ML models
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/torch/hub/checkpoints
-          key: fasterrcnn-258fb6c6+maskrcnn-bf2d0c1e
-      - name: Prepare virtual screen (fake display)
-        run: |
-          sudo apt-get -y install libx11-dev libxtst-dev xvfb vim-common
-          sudo apt-get install -y x11-utils libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
-          Xvfb :99 -screen 0 1024x768x24 &> /tmp/xvfb.log  &
-          sudo touch ~/.Xauthority
-          sudo xauth -f ~/.Xauthority add ${HOST}:99 . $(xxd -l 16 -p /dev/urandom)
-          sudo chmod a+rxw ~/.Xauthority
-          # give xvfb some time to start
-          sleep 3
-      - name: Run current semi-isolation semi-integration tests (to be separated in the future)
-        run: |
-          if [[ "${{ matrix.install_variant }}" != "pip" ]]; then cd packaging && bash packager_docker.sh;
-          else cd tests && bash coverage_analysis.sh; fi
+    - run: sleep 3
+    - name: Cache large ML models
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/torch/hub/checkpoints
+        key: fasterrcnn-258fb6c6+maskrcnn-bf2d0c1e
+    - name: Prepare virtual screen (fake display)
+      run: |
+        sudo apt-get -y install libx11-dev libxtst-dev xvfb vim-common
+        sudo apt-get install -y x11-utils libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+        Xvfb :99 -screen 0 1024x768x24 &> /tmp/xvfb.log  &
+        sudo touch ~/.Xauthority
+        sudo xauth -f ~/.Xauthority add ${HOST}:99 . $(xxd -l 16 -p /dev/urandom)
+        sudo chmod a+rxw ~/.Xauthority
+        # give xvfb some time to start
+        sleep 3
+    - name: Run current semi-isolation semi-integration tests (to be separated in the future)
+      run: |
+        if [[ "${{ matrix.install_variant }}" != "pip" ]]; then cd packaging && bash packager_docker.sh;
+        else cd tests && bash coverage_analysis.sh; fi
         env:
-          INSTALL_VARIANT: ${{ matrix.install_variant }}
-          TESSDATA_PREFIX: /usr/share/tesseract-ocr/5/tessdata
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: tests/coverage.xml
-          verbose: true
-        if: matrix.install_variant == 'pip'
-      - run: echo "🥑 This job's status is ${{ job.status }}."
+        INSTALL_VARIANT: ${{ matrix.install_variant }}
+        TESSDATA_PREFIX: /usr/share/tesseract-ocr/5/tessdata
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: tests/coverage.xml
+        verbose: true
+      if: matrix.install_variant == 'pip'
+    - run: echo "🥑 This job's status is ${{ job.status }}."
 
-      - name: Set Artifacts and Release Variables
-        id: set_vars
-        run: |
-          VERSION="$( cat /home/runner/work/guibot/guibot/VERSION )"
-          # Get the part before the last dot   "0.51" for example
-          prefix=${VERSION%.*}
-          # Get the part after the last dot    "1" for example
-          suffix=${VERSION##*.}
-          # Combine them with a hyphen         "0.51.1" -> "0.51-1"
-          VERSION_HYPHEN="${prefix}-${suffix}"   
-          if [[ "$(echo ${{ matrix.install_variant }} | cut -d '.' -f 2)" == "fedora" ]]; then
-              readonly variant_version=$(echo ${{ matrix.install_variant }} | cut -d '.' -f 3)
-              PACKAGE_NAME="python3-guibot-${VERSION_HYPHEN}.fc${variant_version}.x86_64.rpm"
-              PACKAGE_PATH="/home/runner/work/guibot/guibot/${PACKAGE_NAME}"
-          elif [[ "${{ matrix.install_variant }}" == "pip" ]]; then
-              PACKAGE_NAME="guibot-${VERSION}-py3-none-any.whl"
-              PACKAGE_PATH="/home/runner/work/guibot/guibot/packaging/dist/${PACKAGE_NAME}"
-          else
-              PACKAGE_NAME="python3-guibot_${VERSION_HYPHEN}_all.deb"
-              PACKAGE_PATH="/home/runner/work/guibot/guibot/${PACKAGE_NAME}"
-          fi
-          echo "artifact_name=$PACKAGE_NAME" >> $GITHUB_ENV
-          echo "artifact_full_path=$PACKAGE_PATH" >> $GITHUB_ENV
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          name: '${{ env.artifact_name }}'
-          path: '${{ env.artifact_full_path }}'
-        if: matrix.install_variant != 'pip' || matrix.python-version == 3.13
+    - name: Set Artifacts and Release Variables
+      id: set_vars
+      run: |
+        VERSION="$( cat /home/runner/work/guibot/guibot/VERSION )"
+        # Get the part before the last dot   "0.51" for example
+        prefix=${VERSION%.*}
+        # Get the part after the last dot    "1" for example
+        suffix=${VERSION##*.}
+        # Combine them with a hyphen         "0.51.1" -> "0.51-1"
+        VERSION_HYPHEN="${prefix}-${suffix}"   
+        if [[ "$(echo ${{ matrix.install_variant }} | cut -d '.' -f 2)" == "fedora" ]]; then
+        readonly variant_version=$(echo ${{ matrix.install_variant }} | cut -d '.' -f 3)
+        PACKAGE_NAME="python3-guibot-${VERSION_HYPHEN}.fc${variant_version}.x86_64.rpm"
+        PACKAGE_PATH="/home/runner/work/guibot/guibot/${PACKAGE_NAME}"
+        elif [[ "${{ matrix.install_variant }}" == "pip" ]]; then
+        PACKAGE_NAME="guibot-${VERSION}-py3-none-any.whl"
+        PACKAGE_PATH="/home/runner/work/guibot/guibot/packaging/dist/${PACKAGE_NAME}"
+        else
+        PACKAGE_NAME="python3-guibot_${VERSION_HYPHEN}_all.deb"
+        PACKAGE_PATH="/home/runner/work/guibot/guibot/${PACKAGE_NAME}"
+        fi
+        echo "artifact_name=$PACKAGE_NAME" >> $GITHUB_ENV
+        echo "artifact_full_path=$PACKAGE_PATH" >> $GITHUB_ENV
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        name: '${{ env.artifact_name }}'
+        path: '${{ env.artifact_full_path }}'
+      if: matrix.install_variant != 'pip' || matrix.python-version == 3.13
 
-  windows:
-    name: Windows with any available coverage
-    runs-on: windows-latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up Python 3
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: 'packaging/pip_requirements.txt'
-      - name: Local pip installation on Windows
-        run: |
-          cd packaging
-          pip install --upgrade pip
-          pip install -r pip_requirements.txt
-          pip install .
-      - name: Cache large ML models
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/torch/hub/checkpoints
-          key: fasterrcnn-258fb6c6+maskrcnn-bf2d0c1e
-      - name: Prepare virtual screen (fake display)
-        run: |
-          pip install wxPython==4.2.4
-          python -c "import wx; app = wx.App(); display = wx.Display()"
-      - name: Run current semi-isolation semi-integration tests (to be separated in the future)
-        run: |
-          cd tests
-          bash coverage_analysis.sh
+windows:
+  name: Windows with any available coverage
+  runs-on: windows-latest
+  steps:
+    - name: Check out repository code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'pip'
+        cache-dependency-path: 'packaging/pip_requirements.txt'
+    - name: Local pip installation on Windows
+      run: |
+        cd packaging
+        pip install --upgrade pip
+        pip install -r pip_requirements.txt
+        pip install .
+    - name: Cache large ML models
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/torch/hub/checkpoints
+        key: fasterrcnn-258fb6c6+maskrcnn-bf2d0c1e
+    - name: Prepare virtual screen (fake display)
+      run: |
+        pip install wxPython==4.2.4
+        python -c "import wx; app = wx.App(); display = wx.Display()"
+    - name: Run current semi-isolation semi-integration tests (to be separated in the future)
+      run: |
+        cd tests
+        bash coverage_analysis.sh
         env:
-          # tesseract doesn't have original installers for Windows
-          DISABLE_OCR: 1
-          # drag/drop and in particular drop has problems with AutoPy on Windows
-          DISABLE_DRAG: 1
-          # requires X server and thus only available on Linux
-          DISABLE_XDOTOOL: 1
-          # requires VNC server and thus only available on Linux
-          DISABLE_VNCDOTOOL: 1
+        # tesseract doesn't have original installers for Windows
+        DISABLE_OCR: 1
+        # drag/drop and in particular drop has problems with AutoPy on Windows
+        DISABLE_DRAG: 1
+        # requires X server and thus only available on Linux
+        DISABLE_XDOTOOL: 1
+        # requires VNC server and thus only available on Linux
+        DISABLE_VNCDOTOOL: 1
 
-  macos:
-    name: MacOS with any available coverage
-    # TODO: downgrade from "latest" to 14 due to MacOS 15 suddenly failing a lot of tests
-    # -> should be lifted once we add image logging artifacts to easily debug CI environment
-    runs-on: macos-14
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up Python 3
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-          cache-dependency-path: 'packaging/pip_requirements.txt'
-      - name: Install non-python dependencies using system packager
-        run: |
-          # ocr
-          brew install tesseract
-      - name: Local pip installation on macOS
-        run: |
-          cd packaging
-          pip install --upgrade pip
-          pip install -r pip_requirements.txt
-          pip install .
-      - name: Cache large ML models
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/torch/hub/checkpoints
-          key: fasterrcnn-258fb6c6+maskrcnn-bf2d0c1e
-      - name: Prepare virtual screen (fake display)
-        run: |
-          pip install wxPython==4.2.4
-          python -c "import wx; app = wx.App(); display = wx.Display()"
-      - name: Run current semi-isolation semi-integration tests (to be separated in the future)
-        run: |
-          cd tests
-          bash coverage_analysis.sh
+macos:
+  name: MacOS with any available coverage
+  # TODO: downgrade from "latest" to 14 due to MacOS 15 suddenly failing a lot of tests
+  # -> should be lifted once we add image logging artifacts to easily debug CI environment
+  runs-on: macos-14
+  steps:
+    - name: Check out repository code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3
+      uses: actions/setup-python@v5
+      with:
+      python-version: '3.12'
+      cache: 'pip'
+      cache-dependency-path: 'packaging/pip_requirements.txt'
+    - name: Install non-python dependencies using system packager
+      run: |
+        # ocr
+        brew install tesseract
+    - name: Local pip installation on macOS
+      run: |
+        cd packaging
+        pip install --upgrade pip
+        pip install -r pip_requirements.txt
+        pip install .
+    - name: Cache large ML models
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/torch/hub/checkpoints
+        key: fasterrcnn-258fb6c6+maskrcnn-bf2d0c1e
+    - name: Prepare virtual screen (fake display)
+      run: |
+        pip install wxPython==4.2.4
+        python -c "import wx; app = wx.App(); display = wx.Display()"
+    - name: Run current semi-isolation semi-integration tests (to be separated in the future)
+      run: |
+        cd tests
+        bash coverage_analysis.sh
         env:
-          # drag/drop and in particular drop has problems with AutoPy on macOS
-          DISABLE_DRAG: 1
-          # requires X server and thus only available on Linux
-          DISABLE_XDOTOOL: 1
-          # requires VNC server and thus only available on Linux
-          DISABLE_VNCDOTOOL: 1
-          # TODO: enable PyAutoGUI for macOS if there is more interest
-          DISABLE_PYAUTOGUI: 1
+        # drag/drop and in particular drop has problems with AutoPy on macOS
+        DISABLE_DRAG: 1
+        # requires X server and thus only available on Linux
+        DISABLE_XDOTOOL: 1
+        # requires VNC server and thus only available on Linux
+        DISABLE_VNCDOTOOL: 1
+        # TODO: enable PyAutoGUI for macOS if there is more interest
+        DISABLE_PYAUTOGUI: 1


### PR DESCRIPTION
## Summary

Fixes CI workflow failures across Linux, Windows, and macOS caused by incorrect placement of env: blocks relative to run: steps in .github/workflows/ci.yml.

## Problem

In several steps of the workflow, the env: key was placed *after* the run: | multi-line script block instead of before it. Because of how YAML block scalars work, this caused the env: key (and its contents) to be interpreted as literal text inside the shell script rather than as a separate step property. This resulted in errors such as:

- env:: command not found (Linux/macOS bash)
- The term 'env:' is not recognized as a name of a cmdlet... (Windows PowerShell)

## Fixes

- *Linux job*: Moved env: before run: in the "Run current semi-isolation semi-integration tests" step.
- *Windows job*: Same fix applied to the equivalent step.
- *macOS job*: Same fix applied, and also corrected a follow-up YAML syntax error where DISABLE_PYAUTOGUI had been left outside the env: block after the initial reordering.

## Testing

Verified via GitHub Actions runs on the fork (lormafe34/guibot) after each fix:
- Linux (all Python version/install variant combinations): passing
- Windows: passing
- macOS: passing, *except* for a pre-existing, unrelated flaky test (test_step_save in tests/test_target.py) caused by fragile backend-guessing logic relying on random mkstemp() filenames. This is a separate issue and not something this PR attempts to fix — happy to open a separate issue/PR for it if useful.

## Notes

No functional/test logic was changed — this PR only fixes the CI workflow YAML structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows for more consistent testing across Linux, Windows, and macOS.
  * Standardized Linux build artifact uploads to use the Python wheel.
  * Improved test environment setup and command ordering across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->